### PR TITLE
Fix easypassword failure

### DIFF
--- a/LDAP-Auth/LDAP-Auth.csproj
+++ b/LDAP-Auth/LDAP-Auth.csproj
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.LDAP_Auth</RootNamespace>
-    <AssemblyVersion>2.0.0</AssemblyVersion>
-    <FileVersion>2.0.0</FileVersion>
+    <AssemblyVersion>3.0.0</AssemblyVersion>
+    <FileVersion>3.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Config\configPage.html" />
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.2.*" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.3.*" />
     <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="2.3.8" />
   </ItemGroup>
 </Project>

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -151,14 +151,19 @@ namespace Jellyfin.Plugin.LDAP_Auth
             }
         }
 
+        public Task<bool> HasPassword(User user)
+        {
+            return Task.FromResult(true);
+        }
+
         public Task ChangePassword(User user, string newPassword)
         {
             throw new NotImplementedException("Changing LDAP passwords currently unsupported");
         }
 
-        public Task<bool> HasPassword(User user)
+        public void ChangeEasyPassword(User user, string newPassword, string newPasswordHash)
         {
-            return Task.FromResult(true);
+            throw new NotImplementedException("EasyPin passwords for LDAP users are currently unsupported");
         }
     }
 }

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 ---
 name: "jellyfin-plugin-ldapauth"
 guid: "958aad66-3784-4d2a-b89a-a7b6fab6e25c"
-version: "2" # Please increment with each pull request
-jellyfin_version: "10.3.0" # The earliest binary-compatable version
+version: "3" # Please increment with each pull request
+jellyfin_version: "10.3.5" # The earliest binary-compatable version
 nicename: "LDAP Authentication"
 owner: "jellyfin"
 description: "Authenticate users against an LDAP database"


### PR DESCRIPTION
Implements the ChangeEasyPassword method to ensure compatibility with Jellyfin 10.3.4+. Like the ChangePassword method this just throws a NotImplementedException.

Fixes jellyfin/jellyfin#1445 part 1