### PR TITLE
Implement the GetPasswordHash functions

### DIFF
--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -156,6 +156,16 @@ namespace Jellyfin.Plugin.LDAP_Auth
             return Task.FromResult(true);
         }
 
+        public string GetPasswordHash(User user)
+        {
+            return String.Empty;
+        }
+
+        public string GetEasyPasswordHash(User user)
+        {
+            return String.Empty;
+        }
+
         public Task ChangePassword(User user, string newPassword)
         {
             throw new NotImplementedException("Changing LDAP passwords currently unsupported");


### PR DESCRIPTION
These are also needed by the plugin to build against 10.3.5. They return empty strings since getting this info is irrelevant for functional purposes. Seems to work fine with my instance on 10.3.5.