### PR TITLE
Enable EasyPin login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /LDAP-Auth.sln.DotSettings.user
 /bin/Debug/netstandard2.0
 /.vs/LDAP-Auth/v15
+.idea

--- a/LDAP-Auth/Config/PluginConfiguration.cs
+++ b/LDAP-Auth/Config/PluginConfiguration.cs
@@ -13,6 +13,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
         public string LdapBindPassword { get; set; }
         public bool CreateUsersFromLdap { get; set; }
         public bool UseSsl { get; set; }
+        public string EasyPasswordField { get; set; }
         public bool UseStartTls { get; set; }
         public bool SkipSslVerify { get; set; }
 
@@ -27,6 +28,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
             LdapAdminFilter = "(enabledService=JellyfinAdministrator)";
             LdapBindUser = "CN=BindUser,DC=contoso,DC=com";
             LdapBindPassword = "password";
+            EasyPasswordField = string.Empty;
             CreateUsersFromLdap = true;
             UseSsl = true;
             UseStartTls = false;

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -73,6 +73,10 @@
                                 <input is="emby-input" type="password" id="txtLdapBindPassword" label="LDAP Bind User Password:" />
                                 <div class="fieldDescription">The password for the LDAP search query user.</div>
                             </div>
+                            <div class="inputContainer fldExternalAddressFilter">
+                                <input is="emby-input" type="text" id="txtLdapEasyPasswordAttr" label="LDAP Easy Password Attribute:" />
+                                <div class="fieldDescription">The attribute to store the Easy Password in.</div>
+                            </div>
                             <div class="checkboxContainer checkboxContainer-withDescription">
                                 <label>
                                     <input type="checkbox" is="emby-checkbox" id="chkEnableUserCreation" />
@@ -121,6 +125,7 @@
                     $('#txtLdapAdminFilter', page).val(config.LdapAdminFilter || "(enabledService=JellyfinAdministrator");
                     $('#txtLdapBindUser', page).val(config.LdapBindUser || "CN=BindUser,DC=contoso,DC=com");
                     $('#txtLdapBindPassword', page).val(config.LdapBindPassword || "");
+                    $('#txtLdapEasyPasswordAttr', page).val(config.EasyPasswordField || "");
                     $("#chkEnableUserCreation", page).checked(config.CreateUsersFromLdap);
                     Dashboard.hideLoadingMsg();
                 });
@@ -144,6 +149,7 @@
                     config.LdapAdminFilter = $('#txtLdapAdminFilter', form).val();
                     config.LdapBindUser = $('#txtLdapBindUser', form).val();
                     config.LdapBindPassword = $('#txtLdapBindPassword', form).val();
+                    config.EasyPasswordField = $('#txtLdapEasyPasswordAttr', form).val();
                     config.CreateUsersFromLdap = $("#chkEnableUserCreation", form).checked();
                     config.LdapPort = parseInt($("#txtLdapPort", form).val() || "389");
 

--- a/LDAP-Auth/LDAP-Auth.csproj
+++ b/LDAP-Auth/LDAP-Auth.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.LDAP_Auth</RootNamespace>
-    <AssemblyVersion>6.0.0</AssemblyVersion>
-    <FileVersion>6.0.0</FileVersion>
+    <AssemblyVersion>7.0.0</AssemblyVersion>
+    <FileVersion>7.0.0</FileVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Config\configPage.html" />
@@ -13,7 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Jellyfin.Controller" Version="10.4-*" />
-    <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="2.3.8" />
+    <PackageReference Include="Jellyfin.Controller" Version="10.5-*" />
+    <PackageReference Include="Novell.Directory.Ldap.NETStandard" Version="3.0.3" />
   </ItemGroup>
 </Project>

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -1,8 +1,12 @@
 using System;
+using System.Linq;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Library;
 using MediaBrowser.Controller.Entities;
 using System.Threading.Tasks;
+using MediaBrowser.Common;
+using MediaBrowser.Common.Cryptography;
+using MediaBrowser.Model.Cryptography;
 using Novell.Directory.Ldap;
 using Microsoft.Extensions.Logging;
 
@@ -13,202 +17,284 @@ namespace Jellyfin.Plugin.LDAP_Auth
         private readonly PluginConfiguration _config;
         private readonly ILogger _logger;
         private readonly IUserManager _userManager;
-        public LdapAuthenticationProviderPlugin(IUserManager userManager)
+        private readonly ICryptoProvider _cryptoProvider;
+
+        public LdapAuthenticationProviderPlugin(IUserManager userManager, ICryptoProvider cryptoProvider)
         {
             _config = Plugin.Instance.Configuration;
             _logger = Plugin.Logger;
             _userManager = userManager;
+            _cryptoProvider = cryptoProvider;
         }
 
-        private string[] ldapAttrs => _config.LdapSearchAttributes.Replace(" ", "").Split(',');
+        private string[] ldapUsernameAttributes => _config.LdapSearchAttributes.Replace(" ", string.Empty).Split(',');
+
+        private string[] ldapAttributes => ldapUsernameAttributes.Append(easyPasswordAttr).ToArray();
+
         private string usernameAttr => _config.LdapUsernameAttribute;
         private string searchFilter => _config.LdapSearchFilter;
         private string adminFilter => _config.LdapAdminFilter;
+        private string easyPasswordAttr => _config.EasyPasswordField;
 
         public string Name => "LDAP-Authentication";
 
         public bool IsEnabled => true;
 
-        public async Task<ProviderAuthenticationResult> Authenticate(string username, string password)
+        private LdapEntry LocateLdapUser(string username)
         {
-            User user = null;    
-            bool foundUser = false;
-            LdapEntry ldapUser = null;        
-            using (var ldapClient = new LdapConnection() { SecureSocketLayer = _config.UseSsl })
+            var foundUser = false;
+            LdapEntry ldapUser = null;
+            using (var ldapClient = new LdapConnection {SecureSocketLayer = _config.UseSsl})
             {
                 try
                 {
                     if (_config.SkipSslVerify)
                     {
-                        ldapClient.UserDefinedServerCertValidationDelegate += LdapClient_UserDefinedServerCertValidationDelegate;
+                        ldapClient.UserDefinedServerCertValidationDelegate +=
+                            LdapClient_UserDefinedServerCertValidationDelegate;
                     }
 
-                    ldapClient.Connect(_config.LdapServer,_config.LdapPort);
+                    ldapClient.Connect(_config.LdapServer, _config.LdapPort);
                     if (_config.UseStartTls)
-                    {
                         ldapClient.StartTls();
-                    }
-                    ldapClient.Bind(_config.LdapBindUser,_config.LdapBindPassword);
+
+                    ldapClient.Bind(_config.LdapBindUser, _config.LdapBindPassword);
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
-                    _logger.LogError(e,"Failed to Connect or Bind to server");
-                    throw e;
+                    _logger.LogError(e, "Failed to Connect or Bind to server");
+                    throw new AuthenticationException("Failed to Connect or Bind to server");
                 }
                 finally
                 {
                     ldapClient.UserDefinedServerCertValidationDelegate -= LdapClient_UserDefinedServerCertValidationDelegate;
                 }
 
-                if(ldapClient.Bound)
+                if (!ldapClient.Bound)
+                    return null;
+
+                var ldapUsers =
+                    ldapClient.Search(_config.LdapBaseDn, 2, searchFilter, ldapAttributes, false);
+                if (ldapUsers == null)
                 {
-                    LdapSearchResults ldapUsers = ldapClient.Search(_config.LdapBaseDn, 2, searchFilter, ldapAttrs, false);
-                    if (ldapUsers == null)
+                    _logger.LogWarning("No LDAP users found from query");
+                    throw new UnauthorizedAccessException("No users found in LDAP Query");
+                }
+
+                _logger.LogDebug("Search: {1} {2} @ {3}", _config.LdapBaseDn, searchFilter, _config.LdapServer);
+
+                while (ldapUsers.HasMore() && foundUser == false)
+                {
+                    var currentUser = ldapUsers.Next();
+                    foreach (var attr in ldapUsernameAttributes)
                     {
-                        _logger.LogWarning("No LDAP users found from query");
-                        throw new UnauthorizedAccessException("No users found in LDAP Query");
-                    }
-                    _logger.LogDebug("Search: {1} {2} @ {3}", _config.LdapBaseDn, searchFilter, _config.LdapServer);
-                   
-                    while(ldapUsers.hasMore() && foundUser == false)
-                    {
-                        var currentUser = ldapUsers.next();
-                        foreach(string attr in ldapAttrs)
+                        var toCheck = GetAttribute(currentUser, attr);
+                        if (toCheck?.StringValueArray != null)
                         {
-                            var toCheck = currentUser.getAttribute(attr);
-                            if(toCheck?.StringValueArray != null)
+                            foreach (var name in toCheck.StringValueArray)
                             {
-                                foreach (string name in toCheck.StringValueArray)
+                                if (username == name)
                                 {
-                                    if(username == name)
-                                    {
-                                        ldapUser = currentUser;
-                                        foundUser = true;
-                                    }
+                                    ldapUser = currentUser;
+                                    foundUser = true;
                                 }
                             }
                         }
                     }
+                }
 
-                    if (foundUser == false)
-                    {
-                        _logger.LogError("Found no users matching {1} in LDAP search.", username);
-                        throw new Exception("Found no LDAP users matching provided username.");
-                    }
+                if (foundUser == false)
+                {
+                    _logger.LogError("Found no users matching {1} in LDAP search.", username);
+                    throw new AuthenticationException("Found no LDAP users matching provided username.");
                 }
             }
-            
-            string ldap_username = ldapUser.getAttribute(usernameAttr).StringValue;
-            _logger.LogDebug("Setting username: {1}", ldap_username);
 
-            try
-            {
-                user = _userManager.GetUserByName(ldap_username);
-            }
-            catch(Exception e)
-            {
-                _logger.LogWarning("User Manager could not find a user for LDAP User, this may not be fatal",e);
-            }
+            return ldapUser;
+        }
 
-            using (var ldapClient = new LdapConnection() { SecureSocketLayer = _config.UseSsl })
+        private void SetAttribute(LdapEntry userEntry, string attr, string attrValue)
+        {
+            using (var ldapClient = new LdapConnection {SecureSocketLayer = _config.UseSsl})
             {
-                _logger.LogDebug("Trying bind as user {1}", ldapUser.DN);
                 try
                 {
-                    if(_config.SkipSslVerify)
+                    if (_config.SkipSslVerify)
                     {
-                        ldapClient.UserDefinedServerCertValidationDelegate += LdapClient_UserDefinedServerCertValidationDelegate;
+                        ldapClient.UserDefinedServerCertValidationDelegate +=
+                            LdapClient_UserDefinedServerCertValidationDelegate;
                     }
 
                     ldapClient.Connect(_config.LdapServer, _config.LdapPort);
-                    if(_config.UseStartTls)
-                    {
+                    if (_config.UseStartTls)
                         ldapClient.StartTls();
-                    }
-                    ldapClient.Bind(ldapUser.DN, password);
+
+                    ldapClient.Bind(_config.LdapBindUser, _config.LdapBindPassword);
                 }
-                catch(Exception e)
+                catch (Exception e)
                 {
-                    _logger.LogError(e,"Failed to Connect or Bind to server as user {1}", ldapUser.DN);
-                    throw e;
+                    _logger.LogError(e, "Failed to Connect or Bind to server");
+                    throw new AuthenticationException("Failed to Connect or Bind to server");
                 }
                 finally
                 {
-                    ldapClient.UserDefinedServerCertValidationDelegate -= LdapClient_UserDefinedServerCertValidationDelegate;
+                    ldapClient.UserDefinedServerCertValidationDelegate -=
+                        LdapClient_UserDefinedServerCertValidationDelegate;
                 }
 
-                if(ldapClient.Bound)
+                var existingAttr = GetAttribute(userEntry, attr);
+                var ldapModType = existingAttr == null ? LdapModification.Add : LdapModification.Replace;
+                var modification = new LdapModification(
+                    ldapModType,
+                    new LdapAttribute(attr, attrValue ?? string.Empty)
+                );
+                ldapClient.Modify(userEntry.Dn, modification);
+
+            }
+        }
+
+        private LdapAttribute GetAttribute(LdapEntry userEntry, string attr)
+        {
+            try
+            {
+                return userEntry.GetAttribute(attr);
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning(e, "Error getting LDAP attribute");
+                return null;
+            }
+        }
+
+        public Task<ProviderAuthenticationResult> Authenticate(string username, string password)
+        {
+            User user = null;
+            var ldapUser = LocateLdapUser(username);
+
+            var ldapUsername = GetAttribute(ldapUser, usernameAttr)?.StringValue;
+            _logger.LogDebug("Setting username: {1}", ldapUsername);
+
+            try
+            {
+                user = _userManager.GetUserByName(ldapUsername);
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning("User Manager could not find a user for LDAP User, this may not be fatal", e);
+            }
+
+            using (var ldapClient = new LdapConnection {SecureSocketLayer = _config.UseSsl})
+            {
+                _logger.LogDebug("Trying bind as user {1}", ldapUser.Dn);
+                try
                 {
-                    if(user == null)
+                    ldapClient.Connect(_config.LdapServer, _config.LdapPort);
+                    ldapClient.Bind(ldapUser.Dn, password);
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, "Failed to Connect or Bind to server as user {1}", ldapUser.Dn);
+                    throw new AuthenticationException("Error completing LDAP login. Invalid username or password.", e);
+                }
+
+                if (ldapClient.Bound)
+                {
+                    if (user == null)
                     {
                         // Determine if the user should be an administrator
-                        bool ldap_isAdmin = false;
+                        var ldapIsAdmin = false;
                         // Search the current user DN with the adminFilter
-                        LdapSearchResults ldapUsers = ldapClient.Search(ldapUser.DN, 0, adminFilter, ldapAttrs, false);
-                        var hasMore = ldapUsers.hasMore();
+                        var ldapUsers = ldapClient.Search(ldapUser.Dn, 0, adminFilter, ldapUsernameAttributes,
+                            false);
+
                         // If we got non-zero, then the filter matched and the user is an admin
-                        if(ldapUsers.Count != 0)
+                        if (ldapUsers.Count != 0)
                         {
-                            ldap_isAdmin = true;
+                            ldapIsAdmin = true;
                         }
 
-                        _logger.LogDebug("Creating new user {1} - is admin? {2}", ldap_username, ldap_isAdmin);
-                        if(_config.CreateUsersFromLdap)
+                        _logger.LogDebug("Creating new user {1} - is admin? {2}", ldapUsername, ldapIsAdmin);
+                        if (_config.CreateUsersFromLdap)
                         {
-                            user = _userManager.CreateUser(ldap_username);
+                            user = _userManager.CreateUser(ldapUsername);
                             user.Policy.AuthenticationProviderId = GetType().Name;
-                            user.Policy.IsAdministrator = ldap_isAdmin;
+                            user.Policy.IsAdministrator = ldapIsAdmin;
                             _userManager.UpdateUserPolicy(user.Id, user.Policy);
                         }
                         else
                         {
-                            _logger.LogError($"User not configured for LDAP Uid: {ldap_username}");
-                            throw new Exception($"Automatic User Creation is disabled and there is no Jellyfin user for authorized Uid: {ldap_username}");
+                            _logger.LogError($"User not configured for LDAP Uid: {ldapUsername}");
+                            throw new AuthenticationException(
+                                $"Automatic User Creation is disabled and there is no Jellyfin user for authorized Uid: {ldapUsername}");
                         }
                     }
-                    return new ProviderAuthenticationResult
-                    {
-                        Username = ldap_username
-                    };
+
+                    return Task.FromResult(new ProviderAuthenticationResult {Username = ldapUsername});
                 }
-                else
-                {
-                    _logger.LogError("Error logging in, invalid LDAP username or password");
-                    throw new Exception("Error completing LDAP login. Invalid username or password.");
-                }
+
+                _logger.LogError("Error logging in, invalid LDAP username or password");
+                throw new AuthenticationException("Error completing LDAP login. Invalid username or password.");
             }
         }
-
-        private bool LdapClient_UserDefinedServerCertValidationDelegate(
-            object sender,
-            System.Security.Cryptography.X509Certificates.X509Certificate certificate,
-            System.Security.Cryptography.X509Certificates.X509Chain chain,
-            System.Net.Security.SslPolicyErrors sslPolicyErrors)
-            => true;
 
         public bool HasPassword(User user)
         {
             return true;
         }
 
-        public string GetPasswordHash(User user)
-        {
-            return String.Empty;
-        }
-
+        /// <summary>
+        ///
+        /// </summary>
+        /// <param name="user"></param>
+        /// <returns></returns>
+        /// <inheritdoc/>
         public string GetEasyPasswordHash(User user)
         {
-            return String.Empty;
+            if (string.IsNullOrEmpty(easyPasswordAttr))
+            {
+                return string.Empty;
+            }
+
+            var ldapUser = LocateLdapUser(user.Name);
+            var hash = GetAttribute(ldapUser, easyPasswordAttr)?.StringValue;
+            return string.IsNullOrEmpty(hash)
+                ? null
+                : Hex.Encode(PasswordHash.Parse(hash).Hash);
         }
 
         public Task ChangePassword(User user, string newPassword)
         {
-            throw new NotImplementedException("Changing LDAP passwords currently unsupported");
+            throw new NotImplementedException();
         }
 
-        public void ChangeEasyPassword(User user, string newPassword, string newPasswordHash)
+        public void ChangeEasyPassword(User user, string newPassword, string _)
         {
-            throw new NotImplementedException("EasyPin passwords for LDAP users are currently unsupported");
+            if (string.IsNullOrEmpty(easyPasswordAttr))
+            {
+                throw new ApplicationException("Must configure EasyPassword field");
+            }
+
+            var ldapUser = LocateLdapUser(user.Name);
+            if (ldapUser == null)
+                return;
+
+            var hashString = CreateHash(newPassword);
+            SetAttribute(ldapUser, easyPasswordAttr, hashString);
+            user.EasyPassword = hashString;
         }
+
+        private string CreateHash(string input)
+        {
+            return input == null
+                ? null
+                : _cryptoProvider.CreatePasswordHash(input).ToString();
+        }
+
+        private static bool LdapClient_UserDefinedServerCertValidationDelegate(
+            object sender,
+            System.Security.Cryptography.X509Certificates.X509Certificate certificate,
+            System.Security.Cryptography.X509Certificates.X509Chain chain,
+            System.Net.Security.SslPolicyErrors sslPolicyErrors)
+            => true;
     }
 }

--- a/build.yaml
+++ b/build.yaml
@@ -1,8 +1,8 @@
 ---
 name: "jellyfin-plugin-ldapauth"
 guid: "958aad66-3784-4d2a-b89a-a7b6fab6e25c"
-version: "6" # Please increment with each pull request
-jellyfin_version: "10.4.0" # The earliest binary-compatable version
+version: "7"
+jellyfin_version: "10.5.0"
 nicename: "LDAP Authentication"
 owner: "jellyfin"
 description: "Authenticate users against an LDAP database"
@@ -13,7 +13,7 @@ overview: >
 category: "Authentication"
 build_type: "dotnet"
 dotnet_configuration: "Release"
-dotnet_framework: "netstandard2.0"
+dotnet_framework: "netstandard2.1"
 artifacts:
   - "LDAP-Auth.dll"
   - "Novell.Directory.Ldap.NETStandard.dll"


### PR DESCRIPTION
Until EasyPin is moved out of the Auth provider I allowed the LDAP plugin to use EasyPin. 
Tested with openldap and latest (master) Jellyfin 
No Jellyfin server changes are required.