### PR TITLE
Fix anonymous binds

### DIFF
--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -80,8 +80,9 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     ldapClient.UserDefinedServerCertValidationDelegate -= LdapClient_UserDefinedServerCertValidationDelegate;
                 }
 
-                if (!ldapClient.Bound)
+                if (!ldapClient.Connected)
                 {
+                    _logger.LogWarning("LDAP not connected");
                     return null;
                 }
 


### PR DESCRIPTION
`Bound` is false if this is an anonymous bind cf [here](https://github.com/dsbenghe/Novell.Directory.Ldap.NETStandard/blob/73966b143de7e1d0863909b723d753f0be295d6f/src/Novell.Directory.Ldap.NETStandard/LdapConnection.cs#L385) and [here](https://github.com/dsbenghe/Novell.Directory.Ldap.NETStandard/blob/73966b143de7e1d0863909b723d753f0be295d6f/src/Novell.Directory.Ldap.NETStandard/Connection.cs#L189-L205)

We should use `Connected` instead