### PR TITLE
fix(ci): test-build and codeQL workflow fix

### DIFF
--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -3,21 +3,31 @@ name: Test Build Plugin
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '.github/**'
+      - '**/*.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '.github/**'
+      - '**/*.md'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.x
+
       - name: Install dependencies
         run: dotnet restore
+
       - name: Build
         run: dotnet build --configuration Release
+
       - name: Test
         run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Install dependencies
         run: dotnet restore
       - name: Build
-        run: dotnet build --configuration Release --no-restore
+        run: dotnet build --configuration Release
       - name: Test
         run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -21,12 +21,20 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 5.0.x
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
+
       - name: Autobuild
         uses: github/codeql-action/autobuild@v1
+
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,8 +3,14 @@ name: Run CodeQL
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '.github/**'
+      - '**/*.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '.github/**'
+      - '**/*.md'
   schedule:
     - cron: '24 2 * * 4'
 


### PR DESCRIPTION
**Description**

CodeQL and the basic dotnet build workflow failed for no apparent reason now that 10.7-rc1 is out, so I went and investigated.
* CodeQL just failed to to me messing up and forgetting to configure .Net 5 :sweat_smile: 
* the basic dotnet build workflow failed to to `--no-restore` at build in the `Release` configuration (actually not sure how that can be since this was 100% the configuration suggested by GitHub themselves) :confused: 

Sorry for messing these up in the previous PR :frowning_face: 

**Changes**

* add setup for .Net 5 in CodeQL workflow
* remove `--no-restore` option from `Release` configured build step in test-build workflow
* change workflow trigger to only run on code relevant changes

**Issues**

* None (just me fixing my own errors)