### PR TITLE
chore(ci): centralised release-drafter

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,10 +16,9 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
       time: '00:00'
     open-pull-requests-limit: 10
     commit-message:
-      prefix: fix
-      prefix-development: chore
+      prefix: chore
       include: scope

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,52 +1,9 @@
-# Configuration for Release Drafter: https://github.com/toolmantim/release-drafter
-name-template: Version $NEXT_MAJOR_VERSION
-# Uses a more common single-digit versioning in Jellyfin plugins. Can be replaced by semver: $MAJOR.$MINOR.$PATCH
-# https://github.com/release-drafter/release-drafter#next-version-variables
-tag-template: v$NEXT_MAJOR_VERSION
-version-template: $MAJOR
-
-# Emoji reference: https://gitmoji.carloscuesta.me/
-categories:
-  - title: ":boom: Breaking changes"
-    labels:
-      - breaking
-  - title: 🚨 Removed
-    label: removed
-  - title: ":tada: Major features and improvements"
-    labels:
-      - major-enhancement
-  - title: 🐛 Major bug fixes
-    labels:
-      - major-bug
-  - title: ⚠️ Deprecated
-    label: deprecated
-  - title: 🚀 New features and improvements
-    labels:
-      - enhancement
-      - feature
-  - title: 🐛 Bug Fixes
-    labels:
-      - bug
-      - fix
-      - bugfix
-      - regression
-  # Default label used by Dependabot
-  - title: 📦 Dependency updates
-    label: dependencies
-  - title: 📝 Documentation updates
-    label: documentation
-  - title: 🚦 Tests
-    labels:
-      - test
-      - tests
-exclude-labels:
-  - reverted
-  - no-changelog
-  - skip-changelog
-  - invalid
+_extends: jellyfin-meta-plugins
 
 template: |
   <!-- Optional: add a release summary here -->
   [Plugin build can be downloaded here](https://repo.jellyfin.org/releases/plugin/ldap-authentication/ldap-authentication_$NEXT_MAJOR_VERSION.0.0.0.zip).
+
+  ## :sparkles: What's New
 
   $CHANGES

--- a/.github/workflows/build-dotnet.yml
+++ b/.github/workflows/build-dotnet.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
-      - '.github/**'
       - '**/*.md'
   pull_request:
     branches: [ master ]
     paths-ignore:
-      - '.github/**'
       - '**/*.md'
 
 jobs:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -4,12 +4,10 @@ on:
   push:
     branches: [ master ]
     paths-ignore:
-      - '.github/**'
       - '**/*.md'
   pull_request:
     branches: [ master ]
     paths-ignore:
-      - '.github/**'
       - '**/*.md'
   schedule:
     - cron: '24 2 * * 4'


### PR DESCRIPTION
### Description

As promised in  jellyfin/jellyfin-meta-plugins#3 here a demo of how to use a centralised Release Drafter configuration.

### Changes

* allow GH workflows to run on changes in .github/**
* simplify the dependabot config for github-actions
* change the Release drafter config to 'extend' the centralised version

### Issues

* n/a

**NOTE** I am not sure if we want to keep the `commit-message` dependabot config for nuget packages as is, since it will always end up as `fix`-prefix how it stands right now