### PR TITLE
fix admin lookup condition

### DIFF
--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -106,10 +106,9 @@ namespace Jellyfin.Plugin.LDAP_Auth
                         false);
 
                     // If we got non-zero, then the filter matched and the user is an admin
-                    while (ldapUsers.HasMore())
+                    if (ldapUsers.HasMore())
                     {
                         ldapIsAdmin = true;
-                        break;
                     }
 
                     _logger.LogDebug("Creating new user {Username} - is admin? {IsAdmin}", ldapUsername, ldapIsAdmin);

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -106,9 +106,10 @@ namespace Jellyfin.Plugin.LDAP_Auth
                         false);
 
                     // If we got non-zero, then the filter matched and the user is an admin
-                    if (ldapUsers.Count != 0)
+                    while (ldapUsers.HasMore())
                     {
                         ldapIsAdmin = true;
+                        break;
                     }
 
                     _logger.LogDebug("Creating new user {Username} - is admin? {IsAdmin}", ldapUsername, ldapIsAdmin);


### PR DESCRIPTION
fixes https://github.com/jellyfin/jellyfin-plugin-ldapauth/issues/57

I had the same problem as described in the issue and investigated it a little bit. I could clearly see in my OpenLDAP logs, that the Admin Query returned results, but the debug log message always showed `is admin? False` 

After looking around in the LDAP Library documentation, I could not find a single reference that would confirm the current usage to be valid. Therefore I changed the condition based on the documented methods and now it's working. 

If I'd have to take a guess, I'd say that this might've worked in earlier versions but doesn't anymore, and since this whole block is only triggered on user creation it was probably overlooked when upgrading the dependency.
