### PR TITLE
Changing the LDAP Admin filter can change existing LDAP authenticating users

### DIFF
--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -63,7 +63,9 @@
                             <div class="inputContainer fldExternalAddressFilter">
                                 <input is="emby-input" type="text" id="txtLdapAdminFilter" label="LDAP Admin Filter:" />
                                 <div class="fieldDescription">The LDAP search filter to find administrative users for Jellyfin, e.g. (objectClass=JellyfinAdministrator).
-                                  If blank, administrative state must be configured manually for each user. Applies only to new Jellyfin users on first LDAP authentication.
+                                  If left blank, administrative state must be configured manually for each user. If set, administrative access will automatically be applied
+                                  (either granting or removing administrative access) when the LDAP user next logs in. If the user is currently logged in, this filter will 
+                                  not change their active session permissions.
                                 </div>
                             </div>
                             <div class="inputContainer fldExternalAddressFilter">

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -62,7 +62,9 @@
                             </div>
                             <div class="inputContainer fldExternalAddressFilter">
                                 <input is="emby-input" type="text" id="txtLdapAdminFilter" label="LDAP Admin Filter:" />
-                                <div class="fieldDescription">The LDAP search filter to find administrative users for Jellyfin, e.g. (objectClass=JellyfinAdministrator).</div>
+                                <div class="fieldDescription">The LDAP search filter to find administrative users for Jellyfin, e.g. (objectClass=JellyfinAdministrator).
+                                  If blank, administrative state must be configured manually for each user. Applies only to new Jellyfin users on first LDAP authentication.
+                                </div>
                             </div>
                             <div class="inputContainer fldExternalAddressFilter">
                                 <input is="emby-input" type="text" id="txtLdapBindUser" label="LDAP Bind User:" />
@@ -154,7 +156,8 @@
                         LdapConfigurationPage.txtLdapSearchAttributes.value = config.LdapSearchAttributes || "uid, cn, mail, displayName";
                         LdapConfigurationPage.txtLdapUsernameAttribute.value = config.LdapUsernameAttribute || "uid"; 
                         LdapConfigurationPage.txtLdapSearchFilter.value = config.LdapSearchFilter || "(memberOf=CN=JellyfinUsers,DC=contoso,DC=com)"; 
-                        LdapConfigurationPage.txtLdapAdminFilter.value = config.LdapAdminFilter || "(enabledService=JellyfinAdministrator)";
+                        LdapConfigurationPage.txtLdapAdminFilter.value =
+                          (config.LdapAdminFilter == '_disabled_') ? "" : (config.LdapAdminFilter || "(enabledService=JellyfinAdministrator)");
                         LdapConfigurationPage.txtLdapBindUser.value = config.LdapBindUser || "CN=BindUser,DC=contoso,DC=com";
                         LdapConfigurationPage.txtLdapBindPassword.value = config.LdapBindPassword || "";
                         LdapConfigurationPage.chkEnableUserCreation.checked = config.CreateUsersFromLdap;
@@ -232,7 +235,9 @@
                         config.LdapSearchAttributes = LdapConfigurationPage.txtLdapSearchAttributes.value;
                         config.LdapUsernameAttribute = LdapConfigurationPage.txtLdapUsernameAttribute.value;
                         config.LdapSearchFilter = LdapConfigurationPage.txtLdapSearchFilter.value;
-                        config.LdapAdminFilter = LdapConfigurationPage.txtLdapAdminFilter.value;
+                        config.LdapAdminFilter =
+                          LdapConfigurationPage.txtLdapAdminFilter.value ?
+                          LdapConfigurationPage.txtLdapAdminFilter.value : '_disabled_';
                         config.LdapBindUser = LdapConfigurationPage.txtLdapBindUser.value;
                         config.LdapBindPassword = LdapConfigurationPage.txtLdapBindPassword.value;
                         config.CreateUsersFromLdap = LdapConfigurationPage.chkEnableUserCreation.checked;

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -143,21 +143,21 @@ namespace Jellyfin.Plugin.LDAP_Auth
                 }
                 else
                 {
-                  // User exists; if the admin has enabled an AdminFilter, check if the user's
-                  // 'IsAdministrator' matches the LDAP configuration and update if there is a difference.
-                  //
-                  // Is the AuthenticationProviderId check necessary? Will only users with their
-                  // Authentication Provider set to LDAP be invoked through this flow?
-                  if (!string.IsNullOrEmpty(AdminFilter) && !string.Equals(AdminFilter, "_disabled_", StringComparison.Ordinal))
-                  {
-                    var isJellyfinAdmin = user.HasPermission(PermissionKind.IsAdministrator);
-                    if (isJellyfinAdmin != ldapIsAdmin)
+                    // User exists; if the admin has enabled an AdminFilter, check if the user's
+                    // 'IsAdministrator' matches the LDAP configuration and update if there is a difference.
+                    //
+                    // Is the AuthenticationProviderId check necessary? Will only users with their
+                    // Authentication Provider set to LDAP be invoked through this flow?
+                    if (!string.IsNullOrEmpty(AdminFilter) && !string.Equals(AdminFilter, "_disabled_", StringComparison.Ordinal))
                     {
-                      _logger.LogDebug("Updating user {Username} admin status to: {LdapIsAdmin}.", ldapUsername, ldapIsAdmin);
-                      user.SetPermission(PermissionKind.IsAdministrator, ldapIsAdmin);
-                      await userManager.UpdateUserAsync(user).ConfigureAwait(false);
+                        var isJellyfinAdmin = user.HasPermission(PermissionKind.IsAdministrator);
+                        if (isJellyfinAdmin != ldapIsAdmin)
+                        {
+                            _logger.LogDebug("Updating user {Username} admin status to: {LdapIsAdmin}.", ldapUsername, ldapIsAdmin);
+                            user.SetPermission(PermissionKind.IsAdministrator, ldapIsAdmin);
+                            await userManager.UpdateUserAsync(user).ConfigureAwait(false);
+                        }
                     }
-                  }
                 }
 
                 return new ProviderAuthenticationResult { Username = ldapUsername };

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -97,24 +97,27 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     // Determine if the user should be an administrator
                     var ldapIsAdmin = false;
 
-                    // Automatically follow referrals
-                    ldapClient.Constraints = GetSearchConstraints(
-                        ldapClient,
-                        ldapUser.Dn,
-                        password);
-
-                    // Search the current user DN with the adminFilter
-                    var ldapUsers = ldapClient.Search(
-                        ldapUser.Dn,
-                        0,
-                        AdminFilter,
-                        LdapUsernameAttributes,
-                        false);
-
-                    // If we got non-zero, then the filter matched and the user is an admin
-                    if (ldapUsers.HasMore())
+                    if (!string.IsNullOrEmpty(AdminFilter) && AdminFilter.CompareTo("_disabled_") != 0)
                     {
-                        ldapIsAdmin = true;
+                        // Automatically follow referrals
+                        ldapClient.Constraints = GetSearchConstraints(
+                            ldapClient,
+                            ldapUser.Dn,
+                            password);
+
+                        // Search the current user DN with the adminFilter
+                        var ldapUsers = ldapClient.Search(
+                            ldapUser.Dn,
+                            0,
+                            AdminFilter,
+                            LdapUsernameAttributes,
+                            false);
+
+                        // If we got non-zero, then the filter matched and the user is an admin
+                        if (ldapUsers.HasMore())
+                        {
+                            ldapIsAdmin = true;
+                        }
                     }
 
                     _logger.LogDebug("Creating new user {Username} - is admin? {IsAdmin}", ldapUsername, ldapIsAdmin);

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -145,9 +145,6 @@ namespace Jellyfin.Plugin.LDAP_Auth
                 {
                     // User exists; if the admin has enabled an AdminFilter, check if the user's
                     // 'IsAdministrator' matches the LDAP configuration and update if there is a difference.
-                    //
-                    // Is the AuthenticationProviderId check necessary? Will only users with their
-                    // Authentication Provider set to LDAP be invoked through this flow?
                     if (!string.IsNullOrEmpty(AdminFilter) && !string.Equals(AdminFilter, "_disabled_", StringComparison.Ordinal))
                     {
                         var isJellyfinAdmin = user.HasPermission(PermissionKind.IsAdministrator);

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -148,7 +148,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                   //
                   // Is the AuthenticationProviderId check necessary? Will only users with their
                   // Authentication Provider set to LDAP be invoked through this flow?
-                  if (!string.IsNullOrEmpty(AdminFilter) && AdminFilter.CompareTo("_disabled_") != 0 && user.AuthenticationProviderId == GetType().FullName)
+                  if (!string.IsNullOrEmpty(AdminFilter) && !string.Equals(AdminFilter, "_disabled_", StringComparison.Ordinal))
                   {
                     var isJellyfinAdmin = user.HasPermission(PermissionKind.IsAdministrator);
                     if (isJellyfinAdmin != ldapIsAdmin)

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -95,7 +95,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                 // Determine if the user should be an administrator
                 var ldapIsAdmin = false;
 
-                if (!string.IsNullOrEmpty(AdminFilter) && AdminFilter.CompareTo("_disabled_") != 0)
+                if (!string.IsNullOrEmpty(AdminFilter) && !string.Equals(AdminFilter, "_disabled_", StringComparison.Ordinal))
                 {
                     // Automatically follow referrals
                     ldapClient.Constraints = GetSearchConstraints(

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -153,7 +153,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     var isJellyfinAdmin = user.HasPermission(PermissionKind.IsAdministrator);
                     if (isJellyfinAdmin != ldapIsAdmin)
                     {
-                      _logger.LogDebug("Updating user {Username} admin status to: {ldapIsAdmin}.", ldapUsername, ldapIsAdmin);
+                      _logger.LogDebug("Updating user {Username} admin status to: {LdapIsAdmin}.", ldapUsername, ldapIsAdmin);
                       user.SetPermission(PermissionKind.IsAdministrator, ldapIsAdmin);
                       await userManager.UpdateUserAsync(user).ConfigureAwait(false);
                     }


### PR DESCRIPTION
This two patch series performs the following:

1. Allow the admin to blank out the LDAP filter for configuring Administrators.
2. Adds additional text to the purpose and use of the LDAP admin filter
3. Adds a check if a user exists and logs in to update their admin state based on if an LDAP filter is configured, and if it has changed vs. their currently configured setting.

Note the question toward the bottom of the second patch -- I wasn't sure if the authentication flow is run for all users, or only those users that have their authenticationProviderId set to the LDAP-Auth. Currently the patch checks to make sure the current provider is set to LDAP prior to updating any access.