### PR TITLE
Add Settings Tests

### DIFF
--- a/LDAP-Auth/Api/LdapController.cs
+++ b/LDAP-Auth/Api/LdapController.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Net.Mime;
+using System.Text;
+using Jellyfin.Plugin.LDAP_Auth.Api.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Novell.Directory.Ldap;
+
+namespace Jellyfin.Plugin.LDAP_Auth.Api
+{
+    /// <summary>
+    /// The LDAP api controller.
+    /// </summary>
+    [ApiController]
+    [Authorize(Policy = "RequiresElevation")]
+    [Route("[controller]")]
+    [Produces(MediaTypeNames.Application.Json)]
+    public class LdapController : ControllerBase
+    {
+        private readonly ILogger<LdapController> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LdapController"/> class.
+        /// </summary>
+        /// <param name="logger">The logger.</param>
+        public LdapController(ILogger<LdapController> logger)
+        {
+            _logger = logger;
+        }
+
+        /// <summary>
+        /// Tests the server connection and bind settings.
+        /// </summary>
+        /// <remarks>
+        /// Accepts server connection configuration as JSON body.
+        /// </remarks>
+        /// <response code="200">Server connection was tested.</response>
+        /// <response code="400">Body is missing required data.</response>
+        /// <param name="body">The request body.</param>
+        /// <returns>
+        /// A <see cref="OkResult"/> containing the connection results if able to test,
+        /// or a <see cref="BadRequestResult"/> if the request body is missing data.
+        /// </returns>
+        [HttpPost("TestServerBind")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        public IActionResult TestServerBind([FromBody] ServerConnectionInfo body)
+        {
+            var configuration = LdapPlugin.Instance.Configuration;
+            configuration.LdapServer = body.LdapServer;
+            configuration.LdapPort = body.LdapPort;
+            configuration.UseSsl = body.UseSsl;
+            configuration.UseStartTls = body.UseStartTls;
+            configuration.SkipSslVerify = body.SkipSslVerify;
+            configuration.LdapBindUser = body.LdapBindUser;
+            configuration.LdapBindPassword = body.LdapBindPassword;
+            configuration.LdapBaseDn = body.LdapBaseDn;
+            LdapPlugin.Instance.UpdateConfiguration(configuration);
+
+            var connectionOptions = LdapAuthenticationProviderPlugin.GetConnectionOptions();
+
+            var response = new StringBuilder();
+
+            try
+            {
+                response.Append("Connect (");
+                using var ldapClient = new LdapConnection(connectionOptions);
+                ldapClient.Connect(configuration.LdapServer, configuration.LdapPort);
+                response.Append("Success)");
+
+                if (configuration.UseStartTls)
+                {
+                    response.Append("; Set StartTLS (");
+                    ldapClient.StartTls();
+                    response.Append("Success)");
+                }
+
+                response.Append("; Bind (");
+                ldapClient.Bind(configuration.LdapBindUser, configuration.LdapBindPassword);
+                response.Append("Success)");
+
+                response.Append("; Base Search (");
+                var entries = ldapClient.Search(
+                    configuration.LdapBaseDn,
+                    LdapConnection.ScopeSub,
+                    string.Empty,
+                    Array.Empty<string>(),
+                    false);
+
+                // entries.Count is unreliable (timing issue?), iterate to count
+                var count = 0;
+                while (entries.HasMore())
+                {
+                    entries.Next();
+                    count++;
+                }
+
+                response.Append("Found ").Append(count).Append(" Entities)");
+            }
+            catch (Exception e)
+            {
+                _logger.LogWarning(e, "Ldap Test Failed to Connect or Bind to server");
+                response.Append("Error: ").Append(e.Message).Append(')');
+            }
+
+            return Ok(response.ToString());
+        }
+    }
+}

--- a/LDAP-Auth/Api/Models/ServerConnectionInfo.cs
+++ b/LDAP-Auth/Api/Models/ServerConnectionInfo.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel.DataAnnotations;
+using Jellyfin.Plugin.LDAP_Auth.Config;
+
+namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
+{
+    /// <summary>
+    /// A subset of <see cref="PluginConfiguration"/> containing just the settings for connecting and binding to the server.
+    /// </summary>
+    public class ServerConnectionInfo
+    {
+        /// <summary>
+        /// Gets or sets the ldap host.
+        /// </summary>
+        [Required]
+        public string LdapServer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap port.
+        /// </summary>
+        [Required]
+        public int LdapPort { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether ssl should be used.
+        /// </summary>
+        [Required]
+        public bool UseSsl { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether start tls should be used.
+        /// </summary>
+        [Required]
+        public bool UseStartTls { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether ssl verification should be skipped.
+        /// </summary>
+        [Required]
+        public bool SkipSslVerify { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap bind user.
+        /// </summary>
+        public string LdapBindUser { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the ldap bind password.
+        /// </summary>
+        public string LdapBindPassword { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the ldap base search dn.
+        /// </summary>
+        [Required]
+        public string LdapBaseDn { get; set; }
+    }
+}

--- a/LDAP-Auth/Config/PluginConfiguration.cs
+++ b/LDAP-Auth/Config/PluginConfiguration.cs
@@ -13,19 +13,19 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
         public PluginConfiguration()
         {
             LdapServer = "ldap-server.contoso.com";
-            LdapBaseDn = "o=domains,dc=contoso,dc=com";
             LdapPort = 389;
-            LdapSearchAttributes = "uid, cn, mail, displayName";
-            LdapUsernameAttribute = "uid";
-            LdapSearchFilter = "(memberOf=CN=JellyfinUsers,DC=contoso,DC=com)";
-            LdapAdminFilter = "(enabledService=JellyfinAdministrator)";
-            LdapBindUser = "CN=BindUser,DC=contoso,DC=com";
-            LdapBindPassword = "password";
-            CreateUsersFromLdap = true;
             UseSsl = true;
             UseStartTls = false;
             SkipSslVerify = false;
+            LdapBindUser = "CN=BindUser,DC=contoso,DC=com";
+            LdapBindPassword = "password";
+            LdapBaseDn = "o=domains,dc=contoso,dc=com";
+            LdapSearchFilter = "(memberOf=CN=JellyfinUsers,DC=contoso,DC=com)";
+            LdapAdminFilter = "(enabledService=JellyfinAdministrator)";
+            LdapSearchAttributes = "uid, cn, mail, displayName";
             EnableCaseInsensitiveUsername = false;
+            CreateUsersFromLdap = true;
+            LdapUsernameAttribute = "uid";
             EnableAllFolders = false;
             EnabledFolders = Array.Empty<string>();
         }
@@ -36,49 +36,9 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
         public string LdapServer { get; set; }
 
         /// <summary>
-        /// Gets or sets the ldap base search dn.
-        /// </summary>
-        public string LdapBaseDn { get; set; }
-
-        /// <summary>
         /// Gets or sets the ldap port.
         /// </summary>
         public int LdapPort { get; set; }
-
-        /// <summary>
-        /// Gets or sets the ldap search attributes.
-        /// </summary>
-        public string LdapSearchAttributes { get; set; }
-
-        /// <summary>
-        /// Gets or sets the ldap username attribute.
-        /// </summary>
-        public string LdapUsernameAttribute { get; set; }
-
-        /// <summary>
-        /// Gets or sets the ldap user search filter.
-        /// </summary>
-        public string LdapSearchFilter { get; set; }
-
-        /// <summary>
-        /// Gets or sets the ldap admin search filter.
-        /// </summary>
-        public string LdapAdminFilter { get; set; }
-
-        /// <summary>
-        /// Gets or sets the ldap bind user dn.
-        /// </summary>
-        public string LdapBindUser { get; set; }
-
-        /// <summary>
-        /// Gets or sets the ldap bind user password.
-        /// </summary>
-        public string LdapBindPassword { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to create Jellyfin users from ldap.
-        /// </summary>
-        public bool CreateUsersFromLdap { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to use ssl when connecting to the ldap server.
@@ -96,9 +56,49 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
         public bool SkipSslVerify { get; set; }
 
         /// <summary>
+        /// Gets or sets the ldap bind user dn.
+        /// </summary>
+        public string LdapBindUser { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap bind user password.
+        /// </summary>
+        public string LdapBindPassword { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap base search dn.
+        /// </summary>
+        public string LdapBaseDn { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap user search filter.
+        /// </summary>
+        public string LdapSearchFilter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap admin search filter.
+        /// </summary>
+        public string LdapAdminFilter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap search attributes.
+        /// </summary>
+        public string LdapSearchAttributes { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to use case insensitive username comparison.
         /// </summary>
         public bool EnableCaseInsensitiveUsername { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to create Jellyfin users from ldap.
+        /// </summary>
+        public bool CreateUsersFromLdap { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap username attribute.
+        /// </summary>
+        public string LdapUsernameAttribute { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to enable access to all library folders.

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -14,94 +14,105 @@
                             <a is="emby-button" class="raised button-alt headerHelpButton" target="_blank" href="https://github.com/jellyfin/jellyfin-plugin-ldapauth">${Help}</a>
                         </div>
                         <p><i>Note:</i> Making changes to this configuration requires a restart of Jellyfin.</p>
-                        <div class="verticalSection verticalSection-extrabottompadding">
-                            <div class="inputContainer">
-                                <input is="emby-input" type="text" id="txtLdapServer" label="LDAP Server:" />
-                                <div class="fieldDescription">The server name for the LDAP server you wish to use for Authentication.</div>
-                            </div>
-                            <div class="checkboxContainer checkboxContainer-withDescription">
-                                <label>
-                                    <input type="checkbox" is="emby-checkbox" id="chkUseSsl" />
-                                    <span>Secure LDAP:</span>
-                                </label>
-                                <div class="fieldDescription checkboxFieldDescription">Use SSL for the LDAP connection.</div>
-                            </div>
-                            <div class="checkboxContainer checkboxContainer-withDescription">
-                                <label>
-                                    <input type="checkbox" is="emby-checkbox" id="chkUseStartTls" />
-                                    <span>STARTTLS:</span>
-                                </label>
-                                <div class="fieldDescription checkboxFieldDescription">Use STARTTLS for the LDAP connection.</div>
-                            </div>
-                            <div class="checkboxContainer checkboxContainer-withDescription">
-                                <label>
-                                    <input type="checkbox" is="emby-checkbox" id="chkSkipSslVerify" />
-                                    <span>Skip SSL/TLS Verification:</span>
-                                </label>
-                                <div class="fieldDescription checkboxFieldDescription">Skip verification of connection certificate when using SSL/STARTTLS.</div>
-                            </div>
-                            <div class="inputContainer fldExternalAddressFilter">
-                                <input is="emby-input" type="text" id="txtLdapBaseDn" label="LDAP Base DN for searches:" />
-                                <div class="fieldDescription">The base DN for your LDAP query.</div>
-                            </div>
-                            <div class="inputContainer fldExternalAddressFilter">
-                                <input is="emby-input" type="number" id="txtLdapPort" label="LDAP Port:" />
-                                <div class="fieldDescription">The port to communicate with LDAP.</div>
-                            </div>
-                            <div class="inputContainer fldExternalAddressFilter">
-                                <input is="emby-input" type="text" id="txtLdapSearchAttributes" label="LDAP Attributes:" />
-                                <div class="fieldDescription">A comma-separated list of LDAP attributes to compare with entered usernames.</div>
-                            </div>
-                            <div class="inputContainer fldExternalAddressFilter">
-                                <input is="emby-input" type="text" id="txtLdapUsernameAttribute" label="LDAP Name Attribute:" />
-                                <div class="fieldDescription">The LDAP attribute to create Jellyfin user names from.</div>
-                            </div>
-                            <div class="inputContainer fldExternalAddressFilter">
-                                <input is="emby-input" type="text" id="txtLdapSearchFilter" label="LDAP User Filter:" />
-                                <div class="fieldDescription">The LDAP search filter to find users for Jellyfin, e.g. (objectClass=inetOrgPerson).</div>
-                            </div>
-                            <div class="inputContainer fldExternalAddressFilter">
-                                <input is="emby-input" type="text" id="txtLdapAdminFilter" label="LDAP Admin Filter:" />
-                                <div class="fieldDescription">The LDAP search filter to find administrative users for Jellyfin, e.g. (objectClass=JellyfinAdministrator).
-                                  If left blank, administrative state must be configured manually for each user. If set, administrative access will automatically be applied
-                                  (either granting or removing administrative access) when the LDAP user next logs in. If the user is currently logged in, this filter will 
-                                  not change their active session permissions.
+                        <div class="verticalSection" is="emby-collapse" title="LDAP Server Settings">
+                            <div class="collapseContent">
+                                <div class="inputContainer">
+                                    <input is="emby-input" type="text" id="txtLdapServer" label="LDAP Server:" />
+                                    <div class="fieldDescription">The server name for the LDAP server you wish to use for Authentication.</div>
+                                </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="number" id="txtLdapPort" min="0" label="LDAP Port:" />
+                                    <div class="fieldDescription">The port to communicate with LDAP.</div>
+                                </div>
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label>
+                                        <input type="checkbox" is="emby-checkbox" id="chkUseSsl" />
+                                        <span>Secure LDAP</span>
+                                    </label>
+                                    <div class="fieldDescription checkboxFieldDescription">Use SSL for the LDAP connection.</div>
+                                </div>
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label>
+                                        <input type="checkbox" is="emby-checkbox" id="chkUseStartTls" />
+                                        <span>STARTTLS</span>
+                                    </label>
+                                    <div class="fieldDescription checkboxFieldDescription">Use STARTTLS for the LDAP connection.</div>
+                                </div>
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label>
+                                        <input type="checkbox" is="emby-checkbox" id="chkSkipSslVerify" />
+                                        <span>Skip SSL/TLS Verification</span>
+                                    </label>
+                                    <div class="fieldDescription checkboxFieldDescription">Skip verification of connection certificate when using SSL/STARTTLS.</div>
+                                </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapBindUser" label="LDAP Bind User:" />
+                                    <div class="fieldDescription">A bind user for LDAP search queries, required if your LDAP doesn't support anonymous bind.</div>
+                                </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="password" id="txtLdapBindPassword" label="LDAP Bind User Password:" />
+                                    <div class="fieldDescription">The password for the LDAP search query user.</div>
+                                </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapBaseDn" label="LDAP Base DN for searches:" />
+                                    <div class="fieldDescription">The base DN for your LDAP query.</div>
                                 </div>
                             </div>
-                            <div class="inputContainer fldExternalAddressFilter">
-                                <input is="emby-input" type="text" id="txtLdapBindUser" label="LDAP Bind User:" />
-                                <div class="fieldDescription">A bind user for LDAP search queries, required if your LDAP doesn't support anonymous bind.</div>
+                        </div>
+                        <div class="verticalSection" is="emby-collapse" title="LDAP User Settings">
+                            <div class="collapseContent">
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapSearchFilter" label="LDAP User Filter:" />
+                                    <div class="fieldDescription">The LDAP search filter to find users for Jellyfin, e.g. (objectClass=inetOrgPerson).</div>
+                                </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapAdminFilter" label="LDAP Admin Filter:" />
+                                    <div class="fieldDescription">The LDAP search filter to find administrative users for Jellyfin, e.g. (objectClass=JellyfinAdministrator).
+                                        If left blank, administrative state must be configured manually for each user. If set, administrative access will automatically be applied
+                                        (either granting or removing administrative access) when the LDAP user next logs in. If the user is currently logged in, this filter will
+                                        not change their active session permissions.
+                                    </div>
+                                </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapSearchAttributes" label="LDAP Attributes:" />
+                                    <div class="fieldDescription">A comma-separated list of LDAP attributes to compare with entered usernames.</div>
+                                </div>
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label>
+                                        <input type="checkbox" is="emby-checkbox" id="chkEnableCaseInsensitiveUsername" />
+                                        <span>Enable Case Insensitive Username</span>
+                                    </label>
+                                    <div class="fieldDescription checkboxFieldDescription">Enable case insensitive username comparison</div>
+                                </div>
                             </div>
-                            <div class="inputContainer fldExternalAddressFilter">
-                                <input is="emby-input" type="password" id="txtLdapBindPassword" label="LDAP Bind User Password:" />
-                                <div class="fieldDescription">The password for the LDAP search query user.</div>
+                        </div>
+                        <div class="verticalSection" is="emby-collapse" title="Jellyfin User Settings">
+                            <div class="collapseContent">
+                                <div class="checkboxContainer checkboxContainer-withDescription">
+                                    <label>
+                                        <input type="checkbox" is="emby-checkbox" id="chkEnableUserCreation" />
+                                        <span>Enable User Creation</span>
+                                    </label>
+                                    <div class="fieldDescription checkboxFieldDescription">Enable user creation in Jellyfin on successful LDAP authentication. User must first exist in LDAP.</div>
+                                </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapUsernameAttribute" label="LDAP Name Attribute:" />
+                                    <div class="fieldDescription">The LDAP attribute to create Jellyfin user names from.</div>
+                                </div>
+                                <div class="folderAccessContainer">
+                                    <h2>${HeaderLibraryAccess}</h2>
+                                    <label class="checkboxContainer">
+                                        <input type="checkbox" is="emby-checkbox" id="chkEnableAllFolders" />
+                                        <span>${OptionEnableAccessToAllLibraries}</span>
+                                    </label>
+                                    <div class="folderAccessListContainer">
+                                        <div class="folderAccess">
+                                        </div>
+                                        <div class="fieldDescription">${LibraryAccessHelp}</div>
+                                    </div>
+                                </div>
                             </div>
-                            <div class="checkboxContainer checkboxContainer-withDescription">
-                                <label>
-                                    <input type="checkbox" is="emby-checkbox" id="chkEnableUserCreation" />
-                                    <span>Enable User Creation</span>
-                                </label>
-                                <div class="fieldDescription checkboxFieldDescription">Enable user creation in Jellyfin on successful LDAP authentication. User must first exist in LDAP.</div>
-                            </div>
-                            <div class="checkboxContainer checkboxContainer-withDescription">
-                                <label>
-                                    <input type="checkbox" is="emby-checkbox" id="chkEnableCaseInsensitiveUsername" />
-                                    <span>Enable Case Insensitive Username</span>
-                                </label>
-                                <div class="fieldDescription checkboxFieldDescription">Enable case insensitive username comparison</div>
-                            </div>
-                            <div class="folderAccessContainer">
-                              <h2>${HeaderLibraryAccess}</h2>
-                              <label class="checkboxContainer">
-                                  <input type="checkbox" is="emby-checkbox" id="chkEnableAllFolders" />
-                                  <span>${OptionEnableAccessToAllLibraries}</span>
-                              </label>
-                              <div class="folderAccessListContainer">
-                                  <div class="folderAccess">
-                                  </div>
-                                  <div class="fieldDescription">${LibraryAccessHelp}</div>
-                              </div>
-                            </div>
+                        </div>
                         <div>
                             <button is="emby-button" type="submit" data-theme="b" class="raised button-submit block">
                                 <span>${Save}</span>
@@ -119,21 +130,21 @@
         <script type="text/javascript">
             var LdapConfigurationPage = {
                 pluginUniqueId: "958aad66-3784-4d2a-b89a-a7b6fab6e25c",
-                
+
                 txtLdapServer: document.querySelector("#txtLdapServer"),
+                txtLdapPort: document.querySelector("#txtLdapPort"),
                 chkUseSsl: document.querySelector("#chkUseSsl"),
                 chkUseStartTls: document.querySelector("#chkUseStartTls"),
                 chkSkipSslVerify: document.querySelector("#chkSkipSslVerify"),
-                txtLdapBaseDn: document.querySelector("#txtLdapBaseDn"),
-                txtLdapPort: document.querySelector("#txtLdapPort"),
-                txtLdapSearchAttributes: document.querySelector("#txtLdapSearchAttributes"),
-                txtLdapUsernameAttribute: document.querySelector("#txtLdapUsernameAttribute"),
-                txtLdapSearchFilter: document.querySelector("#txtLdapSearchFilter"),
-                txtLdapAdminFilter: document.querySelector("#txtLdapAdminFilter"),
                 txtLdapBindUser: document.querySelector("#txtLdapBindUser"),
                 txtLdapBindPassword: document.querySelector("#txtLdapBindPassword"),
-                chkEnableUserCreation: document.querySelector("#chkEnableUserCreation"),
+                txtLdapBaseDn: document.querySelector("#txtLdapBaseDn"),
+                txtLdapSearchFilter: document.querySelector("#txtLdapSearchFilter"),
+                txtLdapAdminFilter: document.querySelector("#txtLdapAdminFilter"),
+                txtLdapSearchAttributes: document.querySelector("#txtLdapSearchAttributes"),
                 chkEnableCaseInsensitiveUsername: document.querySelector("#chkEnableCaseInsensitiveUsername"),
+                chkEnableUserCreation: document.querySelector("#chkEnableUserCreation"),
+                txtLdapUsernameAttribute: document.querySelector("#txtLdapUsernameAttribute"),
                 chkEnableAllFolders: document.querySelector('#chkEnableAllFolders'),
                 folderAccessList: document.querySelector('.folderAccess'),
             };
@@ -145,25 +156,25 @@
                     if (!event.detail || !event.detail.params || !event.detail.params.name || event.detail.params.name != 'LDAP-Auth') {
                         return;
                     }
- 
+
                     Dashboard.showLoadingMsg();
 
                     window.ApiClient.getPluginConfiguration(LdapConfigurationPage.pluginUniqueId).then(function (config) {
-                        LdapConfigurationPage.txtLdapServer.value = config.LdapServer || "ldap-server.contoso.com"; 
+                        LdapConfigurationPage.txtLdapServer.value = config.LdapServer || "ldap-server.contoso.com";
+                        LdapConfigurationPage.txtLdapPort.value = config.LdapPort || "389";
                         LdapConfigurationPage.chkUseSsl.checked = config.UseSsl;
                         LdapConfigurationPage.chkUseStartTls.checked = config.UseStartTls;
                         LdapConfigurationPage.chkSkipSslVerify.checked = config.SkipSslVerify;
-                        LdapConfigurationPage.txtLdapBaseDn.value = config.LdapBaseDn || "o=domains,dc=contoso,dc=com";
-                        LdapConfigurationPage.txtLdapPort.value = config.LdapPort || "389";
-                        LdapConfigurationPage.txtLdapSearchAttributes.value = config.LdapSearchAttributes || "uid, cn, mail, displayName";
-                        LdapConfigurationPage.txtLdapUsernameAttribute.value = config.LdapUsernameAttribute || "uid"; 
-                        LdapConfigurationPage.txtLdapSearchFilter.value = config.LdapSearchFilter || "(memberOf=CN=JellyfinUsers,DC=contoso,DC=com)"; 
-                        LdapConfigurationPage.txtLdapAdminFilter.value =
-                          (config.LdapAdminFilter == '_disabled_') ? "" : (config.LdapAdminFilter || "(enabledService=JellyfinAdministrator)");
                         LdapConfigurationPage.txtLdapBindUser.value = config.LdapBindUser || "CN=BindUser,DC=contoso,DC=com";
                         LdapConfigurationPage.txtLdapBindPassword.value = config.LdapBindPassword || "";
-                        LdapConfigurationPage.chkEnableUserCreation.checked = config.CreateUsersFromLdap;
+                        LdapConfigurationPage.txtLdapBaseDn.value = config.LdapBaseDn || "o=domains,dc=contoso,dc=com";
+                        LdapConfigurationPage.txtLdapSearchFilter.value = config.LdapSearchFilter || "(memberOf=CN=JellyfinUsers,DC=contoso,DC=com)";
+                        LdapConfigurationPage.txtLdapAdminFilter.value =
+                            (config.LdapAdminFilter == '_disabled_') ? "" : (config.LdapAdminFilter || "(enabledService=JellyfinAdministrator)");
+                        LdapConfigurationPage.txtLdapSearchAttributes.value = config.LdapSearchAttributes || "uid, cn, mail, displayName";
                         LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked = config.EnableCaseInsensitiveUsername;
+                        LdapConfigurationPage.chkEnableUserCreation.checked = config.CreateUsersFromLdap;
+                        LdapConfigurationPage.txtLdapUsernameAttribute.value = config.LdapUsernameAttribute || "uid";
                         config.EnableAllFolders = config.EnableAllFolders || false;
                         LdapConfigurationPage.chkEnableAllFolders.checked = config.EnableAllFolders;
                         /* Default to empty array if Enabled Folders is not set */
@@ -229,21 +240,21 @@
 
                     window.ApiClient.getPluginConfiguration(LdapConfigurationPage.pluginUniqueId).then(function (config) {
                         config.LdapServer = LdapConfigurationPage.txtLdapServer.value;
+                        config.LdapPort = parseInt(LdapConfigurationPage.txtLdapPort.value || "389");
                         config.UseSsl = LdapConfigurationPage.chkUseSsl.checked;
                         config.UseStartTls = LdapConfigurationPage.chkUseStartTls.checked;
                         config.SkipSslVerify = LdapConfigurationPage.chkSkipSslVerify.checked;
-                        config.LdapBaseDn = LdapConfigurationPage.txtLdapBaseDn.value;
-                        config.LdapPort = parseInt(LdapConfigurationPage.txtLdapPort.value || "389");
-                        config.LdapSearchAttributes = LdapConfigurationPage.txtLdapSearchAttributes.value;
-                        config.LdapUsernameAttribute = LdapConfigurationPage.txtLdapUsernameAttribute.value;
-                        config.LdapSearchFilter = LdapConfigurationPage.txtLdapSearchFilter.value;
-                        config.LdapAdminFilter =
-                          LdapConfigurationPage.txtLdapAdminFilter.value ?
-                          LdapConfigurationPage.txtLdapAdminFilter.value : '_disabled_';
                         config.LdapBindUser = LdapConfigurationPage.txtLdapBindUser.value;
                         config.LdapBindPassword = LdapConfigurationPage.txtLdapBindPassword.value;
-                        config.CreateUsersFromLdap = LdapConfigurationPage.chkEnableUserCreation.checked;
+                        config.LdapBaseDn = LdapConfigurationPage.txtLdapBaseDn.value;
+                        config.LdapSearchFilter = LdapConfigurationPage.txtLdapSearchFilter.value;
+                        config.LdapAdminFilter =
+                            LdapConfigurationPage.txtLdapAdminFilter.value ?
+                                LdapConfigurationPage.txtLdapAdminFilter.value : '_disabled_';
+                        config.LdapSearchAttributes = LdapConfigurationPage.txtLdapSearchAttributes.value;
                         config.EnableCaseInsensitiveUsername = LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked;
+                        config.CreateUsersFromLdap = LdapConfigurationPage.chkEnableUserCreation.checked;
+                        config.LdapUsernameAttribute = LdapConfigurationPage.txtLdapUsernameAttribute.value;
                         /* Map the set of checked input items to an array of library Id's */
                         config.EnableAllFolders = LdapConfigurationPage.chkEnableAllFolders.checked || false;
                         let folders = document.querySelectorAll('#folderList input');

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -57,6 +57,10 @@
                                     <input is="emby-input" type="text" id="txtLdapBaseDn" required placeholder="o=domains,dc=contoso,dc=com" label="LDAP Base DN for searches:" />
                                     <div class="fieldDescription">The base DN for your LDAP query.</div>
                                 </div>
+                                <button id="btnTestServer" is="emby-button" type="button" class="raised button block">
+                                    <span>Save and Test LDAP Server Settings</span>
+                                </button>
+                                <div id="divServerTestResults"></div>
                             </div>
                         </div>
                         <div class="verticalSection" is="emby-collapse" title="LDAP User Settings">
@@ -139,6 +143,7 @@
                 txtLdapBindUser: document.querySelector("#txtLdapBindUser"),
                 txtLdapBindPassword: document.querySelector("#txtLdapBindPassword"),
                 txtLdapBaseDn: document.querySelector("#txtLdapBaseDn"),
+                divServerTestResults: document.querySelector("#divServerTestResults"),
                 txtLdapSearchFilter: document.querySelector("#txtLdapSearchFilter"),
                 txtLdapAdminFilter: document.querySelector("#txtLdapAdminFilter"),
                 txtLdapSearchAttributes: document.querySelector("#txtLdapSearchAttributes"),
@@ -230,7 +235,8 @@
                 }
             });
 
-            document.querySelector(".esqConfigurationForm").addEventListener("submit", function(e){
+            let form = document.querySelector(".esqConfigurationForm");
+            form.addEventListener("submit", function(e){
                 e.preventDefault();
                 Dashboard.showLoadingMsg();
 
@@ -262,6 +268,40 @@
 
                 // Disable default form submission
                 return false;
+            });
+
+            document.querySelector("#btnTestServer").addEventListener("click", function (e) {
+                if (!form.reportValidity()) {
+                    return;
+                }
+
+                Dashboard.showLoadingMsg();
+                LdapConfigurationPage.divServerTestResults.innerText = "";
+
+                const serverConfig = {
+                    LdapServer: LdapConfigurationPage.txtLdapServer.value,
+                    LdapPort: parseInt(LdapConfigurationPage.txtLdapPort.value),
+                    UseSsl: LdapConfigurationPage.chkUseSsl.checked,
+                    UseStartTls: LdapConfigurationPage.chkUseStartTls.checked,
+                    SkipSslVerify: LdapConfigurationPage.chkSkipSslVerify.checked,
+                    LdapBindUser: LdapConfigurationPage.txtLdapBindUser.value,
+                    LdapBindPassword: LdapConfigurationPage.txtLdapBindPassword.value,
+                    LdapBaseDn: LdapConfigurationPage.txtLdapBaseDn.value,
+                }
+
+                const handler = response => response.text().then(message => {
+                    message = message.replace(/^"|"$/g, "");
+                    if (response.ok) {
+                        LdapConfigurationPage.divServerTestResults.innerText = message;
+                    } else {
+                        LdapConfigurationPage.divServerTestResults.innerText = "Failure: " + message;
+                    }
+                    Dashboard.hideLoadingMsg();
+                });
+
+                let url = ApiClient.getUrl('ldap/TestServerBind');
+                let data = JSON.stringify(serverConfig);
+                ApiClient.ajax({ type: 'POST', url, data, contentType: 'application/json' }).then(handler).catch(handler);
             });
         </script>
     </div>

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -149,128 +149,120 @@
                 folderAccessList: document.querySelector('.folderAccess'),
             };
 
-            if (!window.ldapInitialized) {
-                window.ldapInitialized = true;
-                window.addEventListener("pageshow", function (_) {
-                    /* Only take action if the page being shown is 'LDAP-Auth' */
-                    if (!event.detail || !event.detail.params || !event.detail.params.name || event.detail.params.name != 'LDAP-Auth') {
-                        return;
-                    }
+            document.querySelector('.esqConfigurationPage').addEventListener("pageshow", function () {
+                // start with all groups expanded
+                document.querySelectorAll("button#expandButton").forEach(button => button.click());
 
-                    // start with all groups expanded
-                    document.querySelectorAll("button#expandButton").forEach(button => button.click());
+                Dashboard.showLoadingMsg();
 
-                    Dashboard.showLoadingMsg();
-
-                    window.ApiClient.getPluginConfiguration(LdapConfigurationPage.pluginUniqueId).then(function (config) {
-                        LdapConfigurationPage.txtLdapServer.value = config.LdapServer;
-                        LdapConfigurationPage.txtLdapPort.value = config.LdapPort;
-                        LdapConfigurationPage.chkUseSsl.checked = config.UseSsl;
-                        LdapConfigurationPage.chkUseStartTls.checked = config.UseStartTls;
-                        LdapConfigurationPage.chkSkipSslVerify.checked = config.SkipSslVerify;
-                        LdapConfigurationPage.txtLdapBindUser.value = config.LdapBindUser;
-                        LdapConfigurationPage.txtLdapBindPassword.value = config.LdapBindPassword;
-                        LdapConfigurationPage.txtLdapBaseDn.value = config.LdapBaseDn;
-                        LdapConfigurationPage.txtLdapSearchFilter.value = config.LdapSearchFilter;
-                        LdapConfigurationPage.txtLdapAdminFilter.value =
-                            (config.LdapAdminFilter === '_disabled_') ? "" : config.LdapAdminFilter;
-                        LdapConfigurationPage.txtLdapSearchAttributes.value = config.LdapSearchAttributes;
-                        LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked = config.EnableCaseInsensitiveUsername;
-                        LdapConfigurationPage.chkEnableUserCreation.checked = config.CreateUsersFromLdap;
-                        LdapConfigurationPage.txtLdapUsernameAttribute.value = config.LdapUsernameAttribute;
-                        config.EnableAllFolders = config.EnableAllFolders || false;
-                        LdapConfigurationPage.chkEnableAllFolders.checked = config.EnableAllFolders;
-                        /* Default to empty array if Enabled Folders is not set */
-                        config.EnabledFolders = config.EnabledFolders || [];
-                        loadMediaFolders(config).then(() => {
-                          Dashboard.hideLoadingMsg();
-                        });
+                window.ApiClient.getPluginConfiguration(LdapConfigurationPage.pluginUniqueId).then(function (config) {
+                    LdapConfigurationPage.txtLdapServer.value = config.LdapServer;
+                    LdapConfigurationPage.txtLdapPort.value = config.LdapPort;
+                    LdapConfigurationPage.chkUseSsl.checked = config.UseSsl;
+                    LdapConfigurationPage.chkUseStartTls.checked = config.UseStartTls;
+                    LdapConfigurationPage.chkSkipSslVerify.checked = config.SkipSslVerify;
+                    LdapConfigurationPage.txtLdapBindUser.value = config.LdapBindUser;
+                    LdapConfigurationPage.txtLdapBindPassword.value = config.LdapBindPassword;
+                    LdapConfigurationPage.txtLdapBaseDn.value = config.LdapBaseDn;
+                    LdapConfigurationPage.txtLdapSearchFilter.value = config.LdapSearchFilter;
+                    LdapConfigurationPage.txtLdapAdminFilter.value =
+                        (config.LdapAdminFilter === '_disabled_') ? "" : config.LdapAdminFilter;
+                    LdapConfigurationPage.txtLdapSearchAttributes.value = config.LdapSearchAttributes;
+                    LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked = config.EnableCaseInsensitiveUsername;
+                    LdapConfigurationPage.chkEnableUserCreation.checked = config.CreateUsersFromLdap;
+                    LdapConfigurationPage.txtLdapUsernameAttribute.value = config.LdapUsernameAttribute;
+                    config.EnableAllFolders = config.EnableAllFolders || false;
+                    LdapConfigurationPage.chkEnableAllFolders.checked = config.EnableAllFolders;
+                    /* Default to empty array if Enabled Folders is not set */
+                    config.EnabledFolders = config.EnabledFolders || [];
+                    loadMediaFolders(config).then(() => {
+                      Dashboard.hideLoadingMsg();
                     });
+                });
 
-                    const updateFolderListVisibility = () => {
-                        document.querySelector('.folderAccessContainer').style.display =
-                            LdapConfigurationPage.chkEnableUserCreation.checked ? 'block' : 'none';
-                    }
+                const updateFolderListVisibility = () => {
+                    document.querySelector('.folderAccessContainer').style.display =
+                        LdapConfigurationPage.chkEnableUserCreation.checked ? 'block' : 'none';
+                }
 
-                    function loadMediaFolders(config) {
-                      if (!LdapConfigurationPage.folderAccessList) {
-                        return Promise.resolve();
-                      }
+                function loadMediaFolders(config) {
+                  if (!LdapConfigurationPage.folderAccessList) {
+                    return Promise.resolve();
+                  }
 
-                      return window.ApiClient.getJSON(window.ApiClient.getUrl('Library/MediaFolders', {
-                        IsHidden: false
-                      })).then((mediaFolders) => {
-                        let html = '';
-                        html += '<h3 class="checkboxListLabel">${HeaderLibraries}</h3>';
-                        html += '<div id="folderList" class="checkboxList paperList checkboxList-paperList">';
+                  return window.ApiClient.getJSON(window.ApiClient.getUrl('Library/MediaFolders', {
+                    IsHidden: false
+                  })).then((mediaFolders) => {
+                    let html = '';
+                    html += '<h3 class="checkboxListLabel">${HeaderLibraries}</h3>';
+                    html += '<div id="folderList" class="checkboxList paperList checkboxList-paperList">';
 
-                        if (Array.isArray(mediaFolders.Items)) {
-                          mediaFolders.Items.forEach((folder) => {
-                            const isChecked = config.EnableAllFolders || config.EnabledFolders.indexOf(folder.Id) != -1;
-                            const checkedAttribute = isChecked ? ' checked' : '';
-                            html += '<label><input type="checkbox" is="emby-checkbox" class="chkFolder" data-id="' +
-                              folder.Id + '" ' + checkedAttribute + '><span>' + folder.Name +
-                                '</span></label>';
-                          });
-                        }
-
-                        html += '</div>';
-                        LdapConfigurationPage.folderAccessList.innerHTML = html;
-                        /* Only show these options if Jellyfin user creation is enabled on successful LDAP authentication */
-                        updateFolderListVisibility();
-                        LdapConfigurationPage.chkEnableUserCreation.addEventListener('change', updateFolderListVisibility);
-                        /* Set up event handlers for tracking folder enabling/disabling */
-                        Array.prototype.forEach.call(document.querySelectorAll('#folderList input'), (folder) => {
-                          folder.addEventListener('change', (event) => {
-                            const folders = document.querySelectorAll('#folderList input');
-                            let count = 0;
-                            Array.prototype.forEach.call(folders, folder => folder.checked && count++);
-                            LdapConfigurationPage.chkEnableAllFolders.checked = count == folders.length;
-                          });
-                        });
-                        LdapConfigurationPage.chkEnableAllFolders.addEventListener('change', (event) => {
-                          Array.prototype.forEach.call(document.querySelectorAll('#folderList input'), (folder) => {
-                            folder.checked = event.currentTarget.checked;
-                          });
-                        });
+                    if (Array.isArray(mediaFolders.Items)) {
+                      mediaFolders.Items.forEach((folder) => {
+                        const isChecked = config.EnableAllFolders || config.EnabledFolders.indexOf(folder.Id) != -1;
+                        const checkedAttribute = isChecked ? ' checked' : '';
+                        html += '<label><input type="checkbox" is="emby-checkbox" class="chkFolder" data-id="' +
+                          folder.Id + '" ' + checkedAttribute + '><span>' + folder.Name +
+                            '</span></label>';
                       });
                     }
-                });
 
-                document.querySelector(".esqConfigurationForm").addEventListener("submit", function(e){
-                    e.preventDefault();
-                    Dashboard.showLoadingMsg();
-
-                    window.ApiClient.getPluginConfiguration(LdapConfigurationPage.pluginUniqueId).then(function (config) {
-                        config.LdapServer = LdapConfigurationPage.txtLdapServer.value;
-                        config.LdapPort = parseInt(LdapConfigurationPage.txtLdapPort.value);
-                        config.UseSsl = LdapConfigurationPage.chkUseSsl.checked;
-                        config.UseStartTls = LdapConfigurationPage.chkUseStartTls.checked;
-                        config.SkipSslVerify = LdapConfigurationPage.chkSkipSslVerify.checked;
-                        config.LdapBindUser = LdapConfigurationPage.txtLdapBindUser.value;
-                        config.LdapBindPassword = LdapConfigurationPage.txtLdapBindPassword.value;
-                        config.LdapBaseDn = LdapConfigurationPage.txtLdapBaseDn.value;
-                        config.LdapSearchFilter = LdapConfigurationPage.txtLdapSearchFilter.value;
-                        config.LdapAdminFilter =
-                            LdapConfigurationPage.txtLdapAdminFilter.value ?
-                                LdapConfigurationPage.txtLdapAdminFilter.value : '_disabled_';
-                        config.LdapSearchAttributes = LdapConfigurationPage.txtLdapSearchAttributes.value;
-                        config.EnableCaseInsensitiveUsername = LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked;
-                        config.CreateUsersFromLdap = LdapConfigurationPage.chkEnableUserCreation.checked;
-                        config.LdapUsernameAttribute = LdapConfigurationPage.txtLdapUsernameAttribute.value;
-                        /* Map the set of checked input items to an array of library Id's */
-                        config.EnableAllFolders = LdapConfigurationPage.chkEnableAllFolders.checked || false;
-                        let folders = document.querySelectorAll('#folderList input');
-                        folders = Array.prototype.filter.call(folders, folder => folder.checked)
-                          .map(folder => folder.getAttribute("data-id"));
-                        config.EnabledFolders = folders;
-                        window.ApiClient.updatePluginConfiguration(LdapConfigurationPage.pluginUniqueId, config).then(Dashboard.processPluginConfigurationUpdateResult);
+                    html += '</div>';
+                    LdapConfigurationPage.folderAccessList.innerHTML = html;
+                    /* Only show these options if Jellyfin user creation is enabled on successful LDAP authentication */
+                    updateFolderListVisibility();
+                    LdapConfigurationPage.chkEnableUserCreation.addEventListener('change', updateFolderListVisibility);
+                    /* Set up event handlers for tracking folder enabling/disabling */
+                    Array.prototype.forEach.call(document.querySelectorAll('#folderList input'), (folder) => {
+                      folder.addEventListener('change', (event) => {
+                        const folders = document.querySelectorAll('#folderList input');
+                        let count = 0;
+                        Array.prototype.forEach.call(folders, folder => folder.checked && count++);
+                        LdapConfigurationPage.chkEnableAllFolders.checked = count == folders.length;
+                      });
                     });
+                    LdapConfigurationPage.chkEnableAllFolders.addEventListener('change', (event) => {
+                      Array.prototype.forEach.call(document.querySelectorAll('#folderList input'), (folder) => {
+                        folder.checked = event.currentTarget.checked;
+                      });
+                    });
+                  });
+                }
+            });
 
-                    // Disable default form submission
-                    return false;
+            document.querySelector(".esqConfigurationForm").addEventListener("submit", function(e){
+                e.preventDefault();
+                Dashboard.showLoadingMsg();
+
+                window.ApiClient.getPluginConfiguration(LdapConfigurationPage.pluginUniqueId).then(function (config) {
+                    config.LdapServer = LdapConfigurationPage.txtLdapServer.value;
+                    config.LdapPort = parseInt(LdapConfigurationPage.txtLdapPort.value);
+                    config.UseSsl = LdapConfigurationPage.chkUseSsl.checked;
+                    config.UseStartTls = LdapConfigurationPage.chkUseStartTls.checked;
+                    config.SkipSslVerify = LdapConfigurationPage.chkSkipSslVerify.checked;
+                    config.LdapBindUser = LdapConfigurationPage.txtLdapBindUser.value;
+                    config.LdapBindPassword = LdapConfigurationPage.txtLdapBindPassword.value;
+                    config.LdapBaseDn = LdapConfigurationPage.txtLdapBaseDn.value;
+                    config.LdapSearchFilter = LdapConfigurationPage.txtLdapSearchFilter.value;
+                    config.LdapAdminFilter =
+                        LdapConfigurationPage.txtLdapAdminFilter.value ?
+                            LdapConfigurationPage.txtLdapAdminFilter.value : '_disabled_';
+                    config.LdapSearchAttributes = LdapConfigurationPage.txtLdapSearchAttributes.value;
+                    config.EnableCaseInsensitiveUsername = LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked;
+                    config.CreateUsersFromLdap = LdapConfigurationPage.chkEnableUserCreation.checked;
+                    config.LdapUsernameAttribute = LdapConfigurationPage.txtLdapUsernameAttribute.value;
+                    /* Map the set of checked input items to an array of library Id's */
+                    config.EnableAllFolders = LdapConfigurationPage.chkEnableAllFolders.checked || false;
+                    let folders = document.querySelectorAll('#folderList input');
+                    folders = Array.prototype.filter.call(folders, folder => folder.checked)
+                      .map(folder => folder.getAttribute("data-id"));
+                    config.EnabledFolders = folders;
+                    window.ApiClient.updatePluginConfiguration(LdapConfigurationPage.pluginUniqueId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                 });
-            }
+
+                // Disable default form submission
+                return false;
+            });
         </script>
     </div>
 </body>

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -17,11 +17,11 @@
                         <div class="verticalSection" is="emby-collapse" title="LDAP Server Settings">
                             <div class="collapseContent">
                                 <div class="inputContainer">
-                                    <input is="emby-input" type="text" id="txtLdapServer" label="LDAP Server:" />
+                                    <input is="emby-input" type="text" id="txtLdapServer" required placeholder="ldap-server.contoso.com" label="LDAP Server:" />
                                     <div class="fieldDescription">The server name for the LDAP server you wish to use for Authentication.</div>
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
-                                    <input is="emby-input" type="number" id="txtLdapPort" min="0" label="LDAP Port:" />
+                                    <input is="emby-input" type="number" id="txtLdapPort" required min="0" label="LDAP Port:" />
                                     <div class="fieldDescription">The port to communicate with LDAP.</div>
                                 </div>
                                 <div class="checkboxContainer checkboxContainer-withDescription">
@@ -34,9 +34,9 @@
                                 <div class="checkboxContainer checkboxContainer-withDescription">
                                     <label>
                                         <input type="checkbox" is="emby-checkbox" id="chkUseStartTls" />
-                                        <span>STARTTLS</span>
+                                        <span>StartTLS</span>
                                     </label>
-                                    <div class="fieldDescription checkboxFieldDescription">Use STARTTLS for the LDAP connection.</div>
+                                    <div class="fieldDescription checkboxFieldDescription">Use StartTLS for the LDAP connection.</div>
                                 </div>
                                 <div class="checkboxContainer checkboxContainer-withDescription">
                                     <label>
@@ -54,7 +54,7 @@
                                     <div class="fieldDescription">The password for the LDAP search query user.</div>
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
-                                    <input is="emby-input" type="text" id="txtLdapBaseDn" label="LDAP Base DN for searches:" />
+                                    <input is="emby-input" type="text" id="txtLdapBaseDn" required placeholder="o=domains,dc=contoso,dc=com" label="LDAP Base DN for searches:" />
                                     <div class="fieldDescription">The base DN for your LDAP query.</div>
                                 </div>
                             </div>
@@ -62,7 +62,7 @@
                         <div class="verticalSection" is="emby-collapse" title="LDAP User Settings">
                             <div class="collapseContent">
                                 <div class="inputContainer fldExternalAddressFilter">
-                                    <input is="emby-input" type="text" id="txtLdapSearchFilter" label="LDAP User Filter:" />
+                                    <input is="emby-input" type="text" id="txtLdapSearchFilter" required placeholder="(memberOf=CN=JellyfinUsers,DC=contoso,DC=com)" label="LDAP User Filter:" />
                                     <div class="fieldDescription">The LDAP search filter to find users for Jellyfin, e.g. (objectClass=inetOrgPerson).</div>
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
@@ -74,7 +74,7 @@
                                     </div>
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
-                                    <input is="emby-input" type="text" id="txtLdapSearchAttributes" label="LDAP Attributes:" />
+                                    <input is="emby-input" type="text" id="txtLdapSearchAttributes" required placeholder="uid, cn, mail, displayName" label="LDAP Attributes:" />
                                     <div class="fieldDescription">A comma-separated list of LDAP attributes to compare with entered usernames.</div>
                                 </div>
                                 <div class="checkboxContainer checkboxContainer-withDescription">
@@ -157,24 +157,27 @@
                         return;
                     }
 
+                    // start with all groups expanded
+                    document.querySelectorAll("button#expandButton").forEach(button => button.click());
+
                     Dashboard.showLoadingMsg();
 
                     window.ApiClient.getPluginConfiguration(LdapConfigurationPage.pluginUniqueId).then(function (config) {
-                        LdapConfigurationPage.txtLdapServer.value = config.LdapServer || "ldap-server.contoso.com";
-                        LdapConfigurationPage.txtLdapPort.value = config.LdapPort || "389";
+                        LdapConfigurationPage.txtLdapServer.value = config.LdapServer;
+                        LdapConfigurationPage.txtLdapPort.value = config.LdapPort;
                         LdapConfigurationPage.chkUseSsl.checked = config.UseSsl;
                         LdapConfigurationPage.chkUseStartTls.checked = config.UseStartTls;
                         LdapConfigurationPage.chkSkipSslVerify.checked = config.SkipSslVerify;
-                        LdapConfigurationPage.txtLdapBindUser.value = config.LdapBindUser || "CN=BindUser,DC=contoso,DC=com";
-                        LdapConfigurationPage.txtLdapBindPassword.value = config.LdapBindPassword || "";
-                        LdapConfigurationPage.txtLdapBaseDn.value = config.LdapBaseDn || "o=domains,dc=contoso,dc=com";
-                        LdapConfigurationPage.txtLdapSearchFilter.value = config.LdapSearchFilter || "(memberOf=CN=JellyfinUsers,DC=contoso,DC=com)";
+                        LdapConfigurationPage.txtLdapBindUser.value = config.LdapBindUser;
+                        LdapConfigurationPage.txtLdapBindPassword.value = config.LdapBindPassword;
+                        LdapConfigurationPage.txtLdapBaseDn.value = config.LdapBaseDn;
+                        LdapConfigurationPage.txtLdapSearchFilter.value = config.LdapSearchFilter;
                         LdapConfigurationPage.txtLdapAdminFilter.value =
-                            (config.LdapAdminFilter == '_disabled_') ? "" : (config.LdapAdminFilter || "(enabledService=JellyfinAdministrator)");
-                        LdapConfigurationPage.txtLdapSearchAttributes.value = config.LdapSearchAttributes || "uid, cn, mail, displayName";
+                            (config.LdapAdminFilter === '_disabled_') ? "" : config.LdapAdminFilter;
+                        LdapConfigurationPage.txtLdapSearchAttributes.value = config.LdapSearchAttributes;
                         LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked = config.EnableCaseInsensitiveUsername;
                         LdapConfigurationPage.chkEnableUserCreation.checked = config.CreateUsersFromLdap;
-                        LdapConfigurationPage.txtLdapUsernameAttribute.value = config.LdapUsernameAttribute || "uid";
+                        LdapConfigurationPage.txtLdapUsernameAttribute.value = config.LdapUsernameAttribute;
                         config.EnableAllFolders = config.EnableAllFolders || false;
                         LdapConfigurationPage.chkEnableAllFolders.checked = config.EnableAllFolders;
                         /* Default to empty array if Enabled Folders is not set */
@@ -240,7 +243,7 @@
 
                     window.ApiClient.getPluginConfiguration(LdapConfigurationPage.pluginUniqueId).then(function (config) {
                         config.LdapServer = LdapConfigurationPage.txtLdapServer.value;
-                        config.LdapPort = parseInt(LdapConfigurationPage.txtLdapPort.value || "389");
+                        config.LdapPort = parseInt(LdapConfigurationPage.txtLdapPort.value);
                         config.UseSsl = LdapConfigurationPage.chkUseSsl.checked;
                         config.UseStartTls = LdapConfigurationPage.chkUseStartTls.checked;
                         config.SkipSslVerify = LdapConfigurationPage.chkSkipSslVerify.checked;

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -106,7 +106,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     // Search the current user DN with the adminFilter
                     var ldapUsers = ldapClient.Search(
                         ldapUser.Dn,
-                        0,
+                        LdapConnection.ScopeBase,
                         AdminFilter,
                         LdapUsernameAttributes,
                         false);
@@ -216,7 +216,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
 
             var ldapUsers = ldapClient.Search(
                 LdapPlugin.Instance.Configuration.LdapBaseDn,
-                2,
+                LdapConnection.ScopeSub,
                 SearchFilter,
                 LdapUsernameAttributes,
                 false);
@@ -274,7 +274,11 @@ namespace Jellyfin.Plugin.LDAP_Auth
             }
         }
 
-        private static LdapConnectionOptions GetConnectionOptions()
+        /// <summary>
+        /// Bundles the relevant plugin options to connect to the server.
+        /// </summary>
+        /// <returns>The <see cref="LdapConnectionOptions"/> to use for connecting.</returns>
+        public static LdapConnectionOptions GetConnectionOptions()
         {
             var connectionOptions = new LdapConnectionOptions();
             var configuration = LdapPlugin.Instance.Configuration;

--- a/LDAP-Auth/LdapAuthHandler.cs
+++ b/LDAP-Auth/LdapAuthHandler.cs
@@ -19,7 +19,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
         /// Initializes a new instance of the <see cref="LdapAuthHandler" /> class.
         /// </summary>
         /// <param name="logger">Instance of the <see cref="ILogger"/> interface.</param>
-        /// <param name="dn">The distinguised name to use when authenticating to the server.</param>
+        /// <param name="dn">The distinguished name to use when authenticating to the server.</param>
         /// <param name="password">The password to use when authenticating to the server.</param>
         public LdapAuthHandler(ILogger logger, string dn, string password)
         {


### PR DESCRIPTION
Instead of setting everything up and trying to log in, then checking the log to see what went wrong this adds a button to get immediate feedback on the server portion of the settings panel. Similar can be added to the user/admin filter searches once this is settled.

I also reorganized the settings page into panels so related settings are grouped next to each other (loosely based on the flow of the nextcloud ldap settings pages). Panels can be collapsed, because once you've got your server settings working you might as well be able to hide it while working on the next steps.

**Changes**
- Reorganize and group settings into panels (collapsible but expanded by default)
- Use defaults set on server instead of also filling them in on page load
  - Prevents allowable blank fields (such as bind user/pass when using anonymous access) from repopulating
- Remove initialized check that prevented fields from populating in the case that you switched to another plugin config and back without fully reloading the page
- Implement controller, logic, and button for testing LDAP server settings

**Screenshots**
LDAP Server Settings
![image](https://user-images.githubusercontent.com/6081511/143594002-a983391c-0034-4aa2-9439-0507ad55f042.png)

Test with valid server/port but invalid credentials:
![image](https://user-images.githubusercontent.com/6081511/143594987-691514f0-5365-4fbc-b2cd-bed20f3aa649.png)

Test with valid server/port, bind/password, but bad base dn:
![image](https://user-images.githubusercontent.com/6081511/143594842-ddfd43cc-06a0-4198-aaf9-aede7ea43941.png)

Successful test with 4 entities under the provided base dn:
![image](https://user-images.githubusercontent.com/6081511/143595112-4441c2c8-41c9-4c34-bf01-a040ac36f6f9.png)

LDAP User Settings
![image](https://user-images.githubusercontent.com/6081511/143595303-86979f90-a079-4c37-b614-7edf6ab74df0.png)

Jellyfin User Settings
![image](https://user-images.githubusercontent.com/6081511/143595449-0842cd93-a36b-4b6a-9c08-dbd7e3830ff8.png)

**Issues**
First steps for #40 