### PR TITLE
Add User Settings Tests

### DIFF
--- a/LDAP-Auth/Api/LdapController.cs
+++ b/LDAP-Auth/Api/LdapController.cs
@@ -1,5 +1,8 @@
+using System.Linq;
 using System.Net.Mime;
 using Jellyfin.Plugin.LDAP_Auth.Api.Models;
+using MediaBrowser.Common;
+using MediaBrowser.Controller.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -15,6 +18,17 @@ namespace Jellyfin.Plugin.LDAP_Auth.Api
     [Produces(MediaTypeNames.Application.Json)]
     public class LdapController : ControllerBase
     {
+        private readonly LdapAuthenticationProviderPlugin _ldapAuthenticationProvider;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LdapController"/> class.
+        /// </summary>
+        /// <param name="appHost">The application host to get the LDAP Authentication Provider from.</param>
+        public LdapController(IApplicationHost appHost)
+        {
+            _ldapAuthenticationProvider = appHost.GetExports<IAuthenticationProvider>().OfType<LdapAuthenticationProviderPlugin>().FirstOrDefault();
+        }
+
         /// <summary>
         /// Tests the server connection and bind settings.
         /// </summary>
@@ -44,9 +58,9 @@ namespace Jellyfin.Plugin.LDAP_Auth.Api
             configuration.LdapBaseDn = body.LdapBaseDn;
             LdapPlugin.Instance.UpdateConfiguration(configuration);
 
-            var result = LdapAuthenticationProviderPlugin.TestServerBind();
+            var result = _ldapAuthenticationProvider.TestServerBind();
 
-            return Ok(result);
+            return Ok(new { Result = result });
         }
     }
 }

--- a/LDAP-Auth/Api/LdapController.cs
+++ b/LDAP-Auth/Api/LdapController.cs
@@ -28,7 +28,7 @@ namespace Jellyfin.Plugin.LDAP_Auth.Api
         /// <param name="appHost">The application host to get the LDAP Authentication Provider from.</param>
         public LdapController(IApplicationHost appHost)
         {
-            _ldapAuthenticationProvider = appHost.GetExports<IAuthenticationProvider>().OfType<LdapAuthenticationProviderPlugin>().FirstOrDefault();
+            _ldapAuthenticationProvider = appHost.GetExports<LdapAuthenticationProviderPlugin>(false).First();
         }
 
         /// <summary>

--- a/LDAP-Auth/Api/LdapController.cs
+++ b/LDAP-Auth/Api/LdapController.cs
@@ -60,9 +60,7 @@ namespace Jellyfin.Plugin.LDAP_Auth.Api
             configuration.LdapBaseDn = body.LdapBaseDn;
             LdapPlugin.Instance.UpdateConfiguration(configuration);
 
-            var result = _ldapAuthenticationProvider.TestServerBind();
-
-            return Ok(new ServerTestResponse { Result = result });
+            return Ok(_ldapAuthenticationProvider.TestServerBind());
         }
 
         /// <summary>

--- a/LDAP-Auth/Api/Models/ConnectErrorResponse.cs
+++ b/LDAP-Auth/Api/Models/ConnectErrorResponse.cs
@@ -1,0 +1,22 @@
+namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
+{
+    /// <summary>
+    /// Error response to pass message to client when LDAP connection fails.
+    /// </summary>
+    public class ConnectErrorResponse
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConnectErrorResponse"/> class.
+        /// </summary>
+        /// <param name="message">The error message.</param>
+        public ConnectErrorResponse(string message)
+        {
+            Message = message;
+        }
+
+        /// <summary>
+        /// Gets the error message.
+        /// </summary>
+        public string Message { get; }
+    }
+}

--- a/LDAP-Auth/Api/Models/LdapFilterResponse.cs
+++ b/LDAP-Auth/Api/Models/LdapFilterResponse.cs
@@ -1,0 +1,23 @@
+namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
+{
+    /// <summary>
+    /// Response for querying LDAP filters.
+    /// </summary>
+    public class LdapFilterResponse
+    {
+        /// <summary>
+        /// Gets or sets the number of users found by the user filter.
+        /// </summary>
+        public int Users { get; set; }
+
+        /// <summary>
+        /// Gets or sets the number of users found by the admin filter.
+        /// </summary>
+        public int Admins { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether admins is a subset of users.
+        /// </summary>
+        public bool IsSubset { get; set; }
+    }
+}

--- a/LDAP-Auth/Api/Models/LdapTestErrorResponse.cs
+++ b/LDAP-Auth/Api/Models/LdapTestErrorResponse.cs
@@ -1,15 +1,15 @@
 namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
 {
     /// <summary>
-    /// Error response to pass message to client when LDAP connection fails.
+    /// Error response to pass message to client when LDAP testing fails.
     /// </summary>
-    public class ConnectErrorResponse
+    public class LdapTestErrorResponse
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="ConnectErrorResponse"/> class.
+        /// Initializes a new instance of the <see cref="LdapTestErrorResponse"/> class.
         /// </summary>
         /// <param name="message">The error message.</param>
-        public ConnectErrorResponse(string message)
+        public LdapTestErrorResponse(string message)
         {
             Message = message;
         }

--- a/LDAP-Auth/Api/Models/ServerTestResponse.cs
+++ b/LDAP-Auth/Api/Models/ServerTestResponse.cs
@@ -6,8 +6,28 @@ namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
     public class ServerTestResponse
     {
         /// <summary>
-        /// Gets or sets the server connection result message.
+        /// Gets or sets the connect result.
         /// </summary>
-        public string Result { get; set; }
+        public string Connect { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Start TLS result.
+        /// </summary>
+        public string StartTls { get; set; }
+
+        /// <summary>
+        /// Gets or sets the bind result.
+        /// </summary>
+        public string Bind { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Base DN search result.
+        /// </summary>
+        public string BaseSearch { get; set; }
+
+        /// <summary>
+        /// Gets or sets the error message.
+        /// </summary>
+        public string Error { get; set; }
     }
 }

--- a/LDAP-Auth/Api/Models/ServerTestResponse.cs
+++ b/LDAP-Auth/Api/Models/ServerTestResponse.cs
@@ -1,0 +1,13 @@
+namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
+{
+    /// <summary>
+    /// Response for testing server connection.
+    /// </summary>
+    public class ServerTestResponse
+    {
+        /// <summary>
+        /// Gets or sets the server connection result message.
+        /// </summary>
+        public string Result { get; set; }
+    }
+}

--- a/LDAP-Auth/Api/Models/UserFilterInfo.cs
+++ b/LDAP-Auth/Api/Models/UserFilterInfo.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using Jellyfin.Plugin.LDAP_Auth.Config;
+
+namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
+{
+    /// <summary>
+    /// A subset of <see cref="PluginConfiguration"/> containing just the settings for filtering users.
+    /// </summary>
+    public class UserFilterInfo
+    {
+        /// <summary>
+        /// Gets or sets the ldap user search filter.
+        /// </summary>
+        [Required]
+        public string LdapSearchFilter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap admin search filter.
+        /// </summary>
+        public string LdapAdminFilter { get; set; }
+    }
+}

--- a/LDAP-Auth/Api/Models/UserSearchAttributes.cs
+++ b/LDAP-Auth/Api/Models/UserSearchAttributes.cs
@@ -1,0 +1,28 @@
+using System.ComponentModel.DataAnnotations;
+using Jellyfin.Plugin.LDAP_Auth.Config;
+
+namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
+{
+    /// <summary>
+    /// A subset of <see cref="PluginConfiguration"/> containing just the settings for searching for users,
+    /// as well as an optional string to test the search with.
+    /// </summary>
+    public class UserSearchAttributes
+    {
+        /// <summary>
+        /// Gets or sets the ldap search attributes.
+        /// </summary>
+        [Required]
+        public string LdapSearchAttributes { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use case insensitive username comparison.
+        /// </summary>
+        public bool EnableCaseInsensitiveUsername { get; set; }
+
+        /// <summary>
+        /// Gets or sets the username to search for as a test.
+        /// </summary>
+        public string TestSearchUsername { get; set; }
+    }
+}

--- a/LDAP-Auth/Api/Models/UserSearchResponse.cs
+++ b/LDAP-Auth/Api/Models/UserSearchResponse.cs
@@ -1,0 +1,13 @@
+namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
+{
+    /// <summary>
+    /// Response for querying for user.
+    /// </summary>
+    public class UserSearchResponse
+    {
+        /// <summary>
+        /// Gets or sets the located user DN.
+        /// </summary>
+        public string LocatedDn { get; set; }
+    }
+}

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -361,9 +361,9 @@
 
                 const handler = response => response.json().then(res => {
                     if (response.ok) {
-                        LdapConfigurationPage.divSearchTestResults.innerText = res.Found === undefined
+                        LdapConfigurationPage.divSearchTestResults.innerText = res.LocatedDn === undefined
                             ? "No user found"
-                            : "Found user: " + res.Found;
+                            : "Found user: " + res.LocatedDn;
                     } else {
                         LdapConfigurationPage.divSearchTestResults.innerText = "Failure: " + res.Message;
                     }

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -81,6 +81,7 @@
                                     <span>Save and Test LDAP Filter Settings</span>
                                 </button>
                                 <div id="divFilterTestResults"></div>
+                                <hr>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapSearchAttributes" required placeholder="uid, cn, mail, displayName" label="LDAP Attributes:" />
                                     <div class="fieldDescription">A comma-separated list of LDAP attributes to compare with entered usernames.</div>
@@ -92,6 +93,14 @@
                                     </label>
                                     <div class="fieldDescription checkboxFieldDescription">Enable case insensitive username comparison</div>
                                 </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapSearchTest" label="Test Login Name:" />
+                                    <div class="fieldDescription">A user login to search the LDAP for to test attribute configuration.</div>
+                                </div>
+                                <button id="btnTestSearch" is="emby-button" type="button" class="raised button block">
+                                    <span>Save Search Attribute Settings and Query User</span>
+                                </button>
+                                <div id="divSearchTestResults"></div>
                             </div>
                         </div>
                         <div class="verticalSection" is="emby-collapse" title="Jellyfin User Settings">
@@ -153,6 +162,8 @@
                 divFilterTestResults: document.querySelector("#divFilterTestResults"),
                 txtLdapSearchAttributes: document.querySelector("#txtLdapSearchAttributes"),
                 chkEnableCaseInsensitiveUsername: document.querySelector("#chkEnableCaseInsensitiveUsername"),
+                txtLdapSearchTest: document.querySelector("#txtLdapSearchTest"),
+                divSearchTestResults: document.querySelector("#divSearchTestResults"),
                 chkEnableUserCreation: document.querySelector("#chkEnableUserCreation"),
                 txtLdapUsernameAttribute: document.querySelector("#txtLdapUsernameAttribute"),
                 chkEnableAllFolders: document.querySelector('#chkEnableAllFolders'),
@@ -281,7 +292,7 @@
                 Dashboard.showLoadingMsg();
                 LdapConfigurationPage.divServerTestResults.innerText = "";
 
-                const serverConfig = {
+                const configUpdate = {
                     LdapServer: LdapConfigurationPage.txtLdapServer.value,
                     LdapPort: parseInt(LdapConfigurationPage.txtLdapPort.value),
                     UseSsl: LdapConfigurationPage.chkUseSsl.checked,
@@ -302,7 +313,7 @@
                 });
 
                 let url = ApiClient.getUrl('ldap/TestServerBind');
-                let data = JSON.stringify(serverConfig);
+                let data = JSON.stringify(configUpdate);
                 ApiClient.ajax({ type: 'POST', url, data, contentType: 'application/json' }).then(handler).catch(handler);
             });
 
@@ -314,7 +325,7 @@
                 Dashboard.showLoadingMsg();
                 LdapConfigurationPage.divFilterTestResults.innerText = "";
 
-                const serverConfig = {
+                const configUpdate = {
                     LdapSearchFilter: LdapConfigurationPage.txtLdapSearchFilter.value,
                     LdapAdminFilter: LdapConfigurationPage.txtLdapAdminFilter.value || '_disabled_',
                 }
@@ -330,7 +341,37 @@
                 });
 
                 let url = ApiClient.getUrl('ldap/TestLdapFilters');
-                let data = JSON.stringify(serverConfig);
+                let data = JSON.stringify(configUpdate);
+                ApiClient.ajax({ type: 'POST', url, data, contentType: 'application/json' }).then(handler).catch(handler);
+            });
+
+            document.querySelector("#btnTestSearch").addEventListener("click", function (e) {
+                if (!form.reportValidity()) {
+                    return;
+                }
+
+                Dashboard.showLoadingMsg();
+                LdapConfigurationPage.divSearchTestResults.innerText = "";
+
+                const configUpdate = {
+                    LdapSearchAttributes: LdapConfigurationPage.txtLdapSearchAttributes.value,
+                    EnableCaseInsensitiveUsername: LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked,
+                    TestSearchUsername: LdapConfigurationPage.txtLdapSearchTest.value,
+                }
+
+                const handler = response => response.json().then(res => {
+                    if (response.ok) {
+                        LdapConfigurationPage.divSearchTestResults.innerText = res.Found === undefined
+                            ? "No user found"
+                            : "Found user: " + res.Found;
+                    } else {
+                        LdapConfigurationPage.divSearchTestResults.innerText = "Failure: " + res.Message;
+                    }
+                    Dashboard.hideLoadingMsg();
+                });
+
+                let url = ApiClient.getUrl('ldap/LdapUserSearch');
+                let data = JSON.stringify(configUpdate);
                 ApiClient.ajax({ type: 'POST', url, data, contentType: 'application/json' }).then(handler).catch(handler);
             });
         </script>

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -367,17 +367,25 @@
                     LdapAdminFilter: LdapConfigurationPage.txtLdapAdminFilter.value || '_disabled_',
                 }
 
-                const handler = response => response.json().then(res => {
-                    if (response.ok) {
-                        let subsetMessage = res.IsSubset ? "" : ", Warning: Not all Admins are Users";
-                        LdapConfigurationPage.divFilterTestResults.innerText = "Found " + res.Users + " user(s), " + res.Admins + " admin(s)" + subsetMessage;
-                    } else if (res.Message) {
-                        LdapConfigurationPage.divFilterTestResults.innerText = "Failure: " + res.Message;
+                const handler = response => {
+                    if (response.ok || response.status === 400 || response.status === 401) {
+                        response.json().then(res => {
+                            if (response.ok) {
+                                let subsetMessage = res.IsSubset ? "" : ", Warning: Not all Admins are Users";
+                                LdapConfigurationPage.divFilterTestResults.innerText = "Found " + res.Users + " user(s), " + res.Admins + " admin(s)" + subsetMessage;
+                            } else if (res.Message) {
+                                LdapConfigurationPage.divFilterTestResults.innerText = "Failure: " + res.Message;
+                            } else {
+                                LdapConfigurationPage.divFilterTestResults.innerText = "Failure: " + JSON.stringify(res.errors);
+                            }
+                        });
                     } else {
-                        LdapConfigurationPage.divFilterTestResults.innerText = "Failure: " + JSON.stringify(res.errors);
+                        response.text().then(res => {
+                            LdapConfigurationPage.divFilterTestResults.innerText = "Failure: " + res;
+                        });
                     }
                     Dashboard.hideLoadingMsg();
-                });
+                }
 
                 let url = ApiClient.getUrl('ldap/TestLdapFilters');
                 let data = JSON.stringify(configUpdate);
@@ -398,18 +406,26 @@
                     TestSearchUsername: LdapConfigurationPage.txtLdapSearchTest.value,
                 }
 
-                const handler = response => response.json().then(res => {
-                    if (response.ok) {
-                        LdapConfigurationPage.divSearchTestResults.innerText = res.LocatedDn === undefined
-                            ? "No user found"
-                            : "Found user: " + res.LocatedDn;
-                    } else if (res.Message) {
-                        LdapConfigurationPage.divSearchTestResults.innerText = "Failure: " + res.Message;
+                const handler = response => {
+                    if (response.ok || response.status === 400 || response.status === 401) {
+                        response.json().then(res => {
+                            if (response.ok) {
+                                LdapConfigurationPage.divSearchTestResults.innerText = res.LocatedDn === undefined
+                                    ? "No user found"
+                                    : "Found user: " + res.LocatedDn;
+                            } else if (res.Message) {
+                                LdapConfigurationPage.divSearchTestResults.innerText = "Failure: " + res.Message;
+                            } else {
+                                LdapConfigurationPage.divSearchTestResults.innerText = "Failure: " + JSON.stringify(res.errors);
+                            }
+                        });
                     } else {
-                        LdapConfigurationPage.divSearchTestResults.innerText = "Failure: " + JSON.stringify(res.errors);
+                        response.text().then(res => {
+                            LdapConfigurationPage.divSearchTestResults.innerText = "Failure: " + res;
+                        });
                     }
                     Dashboard.hideLoadingMsg();
-                });
+                }
 
                 let url = ApiClient.getUrl('ldap/LdapUserSearch');
                 let data = JSON.stringify(configUpdate);

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -77,6 +77,10 @@
                                         not change their active session permissions.
                                     </div>
                                 </div>
+                                <button id="btnTestFilters" is="emby-button" type="button" class="raised button block">
+                                    <span>Save and Test LDAP Filter Settings</span>
+                                </button>
+                                <div id="divFilterTestResults"></div>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapSearchAttributes" required placeholder="uid, cn, mail, displayName" label="LDAP Attributes:" />
                                     <div class="fieldDescription">A comma-separated list of LDAP attributes to compare with entered usernames.</div>
@@ -146,6 +150,7 @@
                 divServerTestResults: document.querySelector("#divServerTestResults"),
                 txtLdapSearchFilter: document.querySelector("#txtLdapSearchFilter"),
                 txtLdapAdminFilter: document.querySelector("#txtLdapAdminFilter"),
+                divFilterTestResults: document.querySelector("#divFilterTestResults"),
                 txtLdapSearchAttributes: document.querySelector("#txtLdapSearchAttributes"),
                 chkEnableCaseInsensitiveUsername: document.querySelector("#chkEnableCaseInsensitiveUsername"),
                 chkEnableUserCreation: document.querySelector("#chkEnableUserCreation"),
@@ -250,9 +255,7 @@
                     config.LdapBindPassword = LdapConfigurationPage.txtLdapBindPassword.value;
                     config.LdapBaseDn = LdapConfigurationPage.txtLdapBaseDn.value;
                     config.LdapSearchFilter = LdapConfigurationPage.txtLdapSearchFilter.value;
-                    config.LdapAdminFilter =
-                        LdapConfigurationPage.txtLdapAdminFilter.value ?
-                            LdapConfigurationPage.txtLdapAdminFilter.value : '_disabled_';
+                    config.LdapAdminFilter = LdapConfigurationPage.txtLdapAdminFilter.value || '_disabled_';
                     config.LdapSearchAttributes = LdapConfigurationPage.txtLdapSearchAttributes.value;
                     config.EnableCaseInsensitiveUsername = LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked;
                     config.CreateUsersFromLdap = LdapConfigurationPage.chkEnableUserCreation.checked;
@@ -299,6 +302,34 @@
                 });
 
                 let url = ApiClient.getUrl('ldap/TestServerBind');
+                let data = JSON.stringify(serverConfig);
+                ApiClient.ajax({ type: 'POST', url, data, contentType: 'application/json' }).then(handler).catch(handler);
+            });
+
+            document.querySelector("#btnTestFilters").addEventListener("click", function (e) {
+                if (!form.reportValidity()) {
+                    return;
+                }
+
+                Dashboard.showLoadingMsg();
+                LdapConfigurationPage.divFilterTestResults.innerText = "";
+
+                const serverConfig = {
+                    LdapSearchFilter: LdapConfigurationPage.txtLdapSearchFilter.value,
+                    LdapAdminFilter: LdapConfigurationPage.txtLdapAdminFilter.value || '_disabled_',
+                }
+
+                const handler = response => response.json().then(res => {
+                    if (response.ok) {
+                        let subsetMessage = res.IsSubset ? "" : ", Warning: Not all Admins are Users";
+                        LdapConfigurationPage.divFilterTestResults.innerText = "Found " + res.Users + " user(s), " + res.Admins + " admin(s)" + subsetMessage;
+                    } else {
+                        LdapConfigurationPage.divFilterTestResults.innerText = "Failure: " + res.Message;
+                    }
+                    Dashboard.hideLoadingMsg();
+                });
+
+                let url = ApiClient.getUrl('ldap/TestLdapFilters');
                 let data = JSON.stringify(serverConfig);
                 ApiClient.ajax({ type: 'POST', url, data, contentType: 'application/json' }).then(handler).catch(handler);
             });

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -235,7 +235,7 @@
                 }
             });
 
-            let form = document.querySelector(".esqConfigurationForm");
+            var form = document.querySelector(".esqConfigurationForm");
             form.addEventListener("submit", function(e){
                 e.preventDefault();
                 Dashboard.showLoadingMsg();
@@ -289,12 +289,11 @@
                     LdapBaseDn: LdapConfigurationPage.txtLdapBaseDn.value,
                 }
 
-                const handler = response => response.text().then(message => {
-                    message = message.replace(/^"|"$/g, "");
+                const handler = response => response.json().then(res => {
                     if (response.ok) {
-                        LdapConfigurationPage.divServerTestResults.innerText = message;
+                        LdapConfigurationPage.divServerTestResults.innerText = res.Result;
                     } else {
-                        LdapConfigurationPage.divServerTestResults.innerText = "Failure: " + message;
+                        LdapConfigurationPage.divServerTestResults.innerText = "Failure: " + res.Result;
                     }
                     Dashboard.hideLoadingMsg();
                 });

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -305,9 +305,46 @@
 
                 const handler = response => response.json().then(res => {
                     if (response.ok) {
-                        LdapConfigurationPage.divServerTestResults.innerText = res.Result;
+                        const failureString = "Testing...";
+                        let failed = false;
+                        let testString = "Connect"
+                        if (res.Connect === failureString) {
+                            failed = true;
+                            testString += ": " + res.Error;
+                        } else {
+                            testString += " (" + res.Connect + ")";
+                        }
+                        if (!failed && res.StartTls) {
+                            testString += "; Set StartTLS"
+                            if (res.StartTls === failureString) {
+                                failed = true;
+                                testString += ": " + res.Error;
+                            } else {
+                                testString += " (" + res.StartTls + ")";
+                            }
+                        }
+                        if (!failed) {
+                            testString += "; Bind"
+                            if (res.Bind === failureString) {
+                                failed = true;
+                                testString += ": " + res.Error;
+                            } else {
+                                testString += " (" + res.Bind + ")";
+                            }
+                        }
+                        if (!failed) {
+                            testString += "; Base Search"
+                            if (res.BaseSearch === failureString) {
+                                failed = true;
+                                testString += ": " + res.Error;
+                            } else {
+                                testString += " (" + res.BaseSearch + ")";
+                            }
+                        }
+
+                        LdapConfigurationPage.divServerTestResults.innerText = testString;
                     } else {
-                        LdapConfigurationPage.divServerTestResults.innerText = "Failure: " + res.Result;
+                        LdapConfigurationPage.divServerTestResults.innerText = "Failure: " + JSON.stringify(res.errors);
                     }
                     Dashboard.hideLoadingMsg();
                 });
@@ -334,8 +371,10 @@
                     if (response.ok) {
                         let subsetMessage = res.IsSubset ? "" : ", Warning: Not all Admins are Users";
                         LdapConfigurationPage.divFilterTestResults.innerText = "Found " + res.Users + " user(s), " + res.Admins + " admin(s)" + subsetMessage;
-                    } else {
+                    } else if (res.Message) {
                         LdapConfigurationPage.divFilterTestResults.innerText = "Failure: " + res.Message;
+                    } else {
+                        LdapConfigurationPage.divFilterTestResults.innerText = "Failure: " + JSON.stringify(res.errors);
                     }
                     Dashboard.hideLoadingMsg();
                 });
@@ -364,8 +403,10 @@
                         LdapConfigurationPage.divSearchTestResults.innerText = res.LocatedDn === undefined
                             ? "No user found"
                             : "Found user: " + res.LocatedDn;
-                    } else {
+                    } else if (res.Message) {
                         LdapConfigurationPage.divSearchTestResults.innerText = "Failure: " + res.Message;
+                    } else {
+                        LdapConfigurationPage.divSearchTestResults.innerText = "Failure: " + JSON.stringify(res.errors);
                     }
                     Dashboard.hideLoadingMsg();
                 });

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -233,15 +233,14 @@ namespace Jellyfin.Plugin.LDAP_Auth
 
         private LdapAttribute GetAttribute(LdapEntry userEntry, string attr)
         {
-            try
+            var attributeSet = userEntry.GetAttributeSet();
+            if (attributeSet.ContainsKey(attr))
             {
-                return userEntry.GetAttribute(attr);
+                return attributeSet.GetAttribute(attr);
             }
-            catch (Exception e)
-            {
-                _logger.LogWarning(e, "Error getting LDAP attribute");
-                return null;
-            }
+
+            _logger.LogWarning("LDAP attribute {attr} not found for user {user}", attr, userEntry.Dn);
+            return null;
         }
 
         private static LdapConnectionOptions GetConnectionOptions()

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -267,7 +267,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                 return attributeSet.GetAttribute(attr);
             }
 
-            _logger.LogWarning("LDAP attribute {attr} not found for user {user}", attr, userEntry.Dn);
+            _logger.LogWarning("LDAP attribute {Attr} not found for user {User}", attr, userEntry.Dn);
             return null;
         }
 
@@ -316,7 +316,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     ldapClient.StartTls();
                 }
 
-                _logger.LogDebug("Trying bind as user {userDn}", userDn);
+                _logger.LogDebug("Trying bind as user {UserDn}", userDn);
                 ldapClient.Bind(userDn, userPassword);
             }
             catch (Exception e)

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -305,7 +305,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
         /// Tests the server connection and bind settings.
         /// </summary>
         /// <returns>A string reporting the result of the sequence of connection steps.</returns>
-        public static string TestServerBind()
+        public string TestServerBind()
         {
             var configuration = LdapPlugin.Instance.Configuration;
             var connectionOptions = GetConnectionOptions();
@@ -349,6 +349,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
             }
             catch (Exception e)
             {
+                _logger.LogWarning(e, "Ldap Test Failed to Connect or Bind to server");
                 response.Append("Error: ").Append(e.Message).Append(')');
             }
 


### PR DESCRIPTION
**Changes**
- Minor cleanup and refactoring to improve reusability of code
- Implemented testing of user/admin filters - displays counts for each and warns if admins aren't users
- Implemented test query of a user log in

**Screenshots**
LDAP User Settings
![image](https://user-images.githubusercontent.com/6081511/144519070-08a18cc7-2d95-4bf2-b02b-de2d84960321.png)

Valid filters with matches
![image](https://user-images.githubusercontent.com/6081511/144519716-83135cc1-b1d0-42c3-8518-cc18671fe19c.png)

Empty user filter, admin warning
![image](https://user-images.githubusercontent.com/6081511/144519795-22f96a38-c3cb-4d58-9a7a-25cd6259f807.png)

No user found
![image](https://user-images.githubusercontent.com/6081511/144519992-dbdaeb5c-aae3-4409-bff9-71df4c42fb86.png)

User found
![image](https://user-images.githubusercontent.com/6081511/144520121-7452b6af-7a92-48d5-acdd-01e62b1de262.png)

Unable to search due to LDAP connection failure
![image](https://user-images.githubusercontent.com/6081511/144520202-5f0fa8e5-9923-4101-ab3e-69d19c54cd6a.png)

**Issues**
Fixes #40 