### PR TITLE
OpenLDAP admin memberUid support

### DIFF
--- a/LDAP-Auth/Config/PluginConfiguration.cs
+++ b/LDAP-Auth/Config/PluginConfiguration.cs
@@ -21,6 +21,7 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
             LdapBindPassword = "password";
             LdapBaseDn = "o=domains,dc=contoso,dc=com";
             LdapSearchFilter = "(memberOf=CN=JellyfinUsers,DC=contoso,DC=com)";
+            LdapAdminBaseDn = string.Empty;
             LdapAdminFilter = "(enabledService=JellyfinAdministrator)";
             LdapSearchAttributes = "uid, cn, mail, displayName";
             EnableCaseInsensitiveUsername = false;
@@ -74,6 +75,11 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
         /// Gets or sets the ldap user search filter.
         /// </summary>
         public string LdapSearchFilter { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap admin search base dn.
+        /// </summary>
+        public string LdapAdminBaseDn { get; set; }
 
         /// <summary>
         /// Gets or sets the ldap admin search filter.

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -79,8 +79,12 @@
                                     <div class="fieldDescription">The LDAP search filter to find users for Jellyfin, e.g. (objectClass=inetOrgPerson).</div>
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapAdminBaseDn" label="LDAP Admin Base DN:" />
+                                    <div class="fieldDescription">The LDAP search base dn to find administrative users for Jellyfin, e.g. (cn=admins,dc=contoso,dc=com). Defaults to user dn if empty</div>
+                                </div>
+                                <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapAdminFilter" label="LDAP Admin Filter:" />
-                                    <div class="fieldDescription">The LDAP search filter to find administrative users for Jellyfin, e.g. (objectClass=JellyfinAdministrator).
+                                    <div class="fieldDescription">The LDAP search filter to find administrative users for Jellyfin, e.g. (objectClass=JellyfinAdministrator). Variable {username} is available for more complex filters e.g. (memberUid={username}). 
                                         If left blank, administrative state must be configured manually for each user. If set, administrative access will automatically be applied
                                         (either granting or removing administrative access) when the LDAP user next logs in. If the user is currently logged in, this filter will
                                         not change their active session permissions.
@@ -167,6 +171,7 @@
                 txtLdapBaseDn: document.querySelector("#txtLdapBaseDn"),
                 divServerTestResults: document.querySelector("#divServerTestResults"),
                 txtLdapSearchFilter: document.querySelector("#txtLdapSearchFilter"),
+                txtLdapAdminBaseDn: document.querySelector("#txtLdapAdminBaseDn"),
                 txtLdapAdminFilter: document.querySelector("#txtLdapAdminFilter"),
                 divFilterTestResults: document.querySelector("#divFilterTestResults"),
                 txtLdapSearchAttributes: document.querySelector("#txtLdapSearchAttributes"),
@@ -196,6 +201,7 @@
                     LdapConfigurationPage.txtLdapBindPassword.value = config.LdapBindPassword;
                     LdapConfigurationPage.txtLdapBaseDn.value = config.LdapBaseDn;
                     LdapConfigurationPage.txtLdapSearchFilter.value = config.LdapSearchFilter;
+                    LdapConfigurationPage.txtLdapAdminBaseDn.value = config.LdapAdminBaseDn || "";
                     LdapConfigurationPage.txtLdapAdminFilter.value =
                         (config.LdapAdminFilter === '_disabled_') ? "" : config.LdapAdminFilter;
                     LdapConfigurationPage.txtLdapSearchAttributes.value = config.LdapSearchAttributes;
@@ -277,6 +283,7 @@
                     config.LdapBindPassword = LdapConfigurationPage.txtLdapBindPassword.value;
                     config.LdapBaseDn = LdapConfigurationPage.txtLdapBaseDn.value;
                     config.LdapSearchFilter = LdapConfigurationPage.txtLdapSearchFilter.value;
+                    config.LdapAdminBaseDn = LdapConfigurationPage.txtLdapAdminBaseDn.value;
                     config.LdapAdminFilter = LdapConfigurationPage.txtLdapAdminFilter.value || '_disabled_';
                     config.LdapSearchAttributes = LdapConfigurationPage.txtLdapSearchAttributes.value;
                     config.EnableCaseInsensitiveUsername = LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked;

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -102,11 +102,17 @@ namespace Jellyfin.Plugin.LDAP_Auth
 
                 try
                 {
+                    var adminBaseDn = LdapPlugin.Instance.Configuration.LdapAdminBaseDn;
+                    if (string.IsNullOrEmpty(adminBaseDn))
+                    {
+                        adminBaseDn = ldapUser.Dn;
+                    }
+
                     // Search the current user DN with the adminFilter
                     var ldapUsers = ldapClient.Search(
-                        ldapUser.Dn,
+                        adminBaseDn,
                         LdapConnection.ScopeBase,
-                        AdminFilter,
+                        AdminFilter.Replace("{username}", username, StringComparison.OrdinalIgnoreCase),
                         LdapUsernameAttributes,
                         false);
 


### PR DESCRIPTION
This adds a support for a memberUid feature (OpenLDAP did not support memberOf in the beginning).
Example admin group with the list of admin uids:
```
dn: cn=syncloud,ou=groups,dc=syncloud,dc=org
objectClass: posixGroup
objectClass: top
gidNumber: 1
cn: syncloud
description: Syncloud
memberUid: user1
memberUid: user2
```
Example user:
```
dn: cn=user1,ou=users,dc=syncloud,dc=org
objectClass: simpleSecurityObject
objectClass: person
objectClass: inetOrgPerson
objectClass: posixAccount
uidNumber: 10
gidNumber: 10
homeDirectory: user1
uid: user1
cn: user1
sn: user1
displayName: user1
description: user1
```

Example config:
```
  <LdapAdminBaseDn>cn=syncloud,ou=groups,dc=syncloud</LdapAdminBaseDn>
  <LdapAdminFilter>memberUid={username}</LdapAdminFilter>
```
where username is what user enters into the login field, so admin filter has to be more dynamic and hence the `{username}` variable support.

The feature does not break the existing logic as if `LdapAdminBaseDn` is left blank it will fallback to the current user dn.
