### PR TITLE
Expand certificate support for LDAP authentication

### DIFF
--- a/LDAP-Auth/Api/LdapController.cs
+++ b/LDAP-Auth/Api/LdapController.cs
@@ -62,6 +62,9 @@ namespace Jellyfin.Plugin.LDAP_Auth.Api
             configuration.LdapBindPassword = body.LdapBindPassword;
             configuration.LdapBaseDn = body.LdapBaseDn;
             configuration.PasswordResetUrl = body.PasswordResetUrl;
+            configuration.LdapClientCertPath = body.LdapClientCertPath;
+            configuration.LdapClientKeyPath = body.LdapClientKeyPath;
+            configuration.LdapRootCaPath = body.LdapRootCaPath;
             LdapPlugin.Instance.UpdateConfiguration(configuration);
 
             return Ok(_ldapAuthenticationProvider.TestServerBind());

--- a/LDAP-Auth/Api/Models/ServerConnectionInfo.cs
+++ b/LDAP-Auth/Api/Models/ServerConnectionInfo.cs
@@ -64,5 +64,20 @@ namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
         /// Gets or sets the password reset url.
         /// </summary>
         public string PasswordResetUrl { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client cert name.
+        /// </summary>
+        public string LdapClientCertPath { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the client key name.
+        /// </summary>
+        public string LdapClientKeyPath { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the root ca chain cert name.
+        /// </summary>
+        public string LdapRootCaPath { get; set; } = string.Empty;
     }
 }

--- a/LDAP-Auth/Config/PluginConfiguration.cs
+++ b/LDAP-Auth/Config/PluginConfiguration.cs
@@ -25,6 +25,9 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
             LdapAdminBaseDn = string.Empty;
             LdapAdminFilter = "(enabledService=JellyfinAdministrator)";
             LdapSearchAttributes = "uid, cn, mail, displayName";
+            LdapClientCertPath = string.Empty;
+            LdapClientKeyPath = string.Empty;
+            LdapRootCaPath = string.Empty;
             EnableCaseInsensitiveUsername = false;
             CreateUsersFromLdap = true;
             LdapUsernameAttribute = "uid";
@@ -97,6 +100,21 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
         /// Gets or sets a value indicating whether to use case insensitive username comparison.
         /// </summary>
         public bool EnableCaseInsensitiveUsername { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap client cert path.
+        /// </summary>
+        public string LdapClientCertPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap client cert path.
+        /// </summary>
+        public string LdapClientKeyPath { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap root CA path.
+        /// </summary>
+        public string LdapRootCaPath { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to create Jellyfin users from ldap.

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -38,6 +38,18 @@
                                     </label>
                                     <div class="fieldDescription checkboxFieldDescription">Use StartTLS for the LDAP connection.</div>
                                 </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapClientCertPath" label="LDAP Client Cert Path:" />
+                                    <div class="fieldDescription">Optional path to a TLS cert for LDAP client verification. </div>
+                                </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapClientKeyPath" label="LDAP Client Key Path:" />
+                                    <div class="fieldDescription">Optional path to a TLS key for LDAP client verification. </div>
+                                </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapRootCaPath" label="LDAP Root CA Path:" />
+                                    <div class="fieldDescription">Optional path to a cert bundle to use for LDAP server verification..</div>
+                                </div>
                                 <div class="checkboxContainer checkboxContainer-withDescription">
                                     <label>
                                         <input type="checkbox" is="emby-checkbox" id="chkSkipSslVerify" />
@@ -190,6 +202,9 @@
                 chkEnableCaseInsensitiveUsername: document.querySelector("#chkEnableCaseInsensitiveUsername"),
                 txtLdapSearchTest: document.querySelector("#txtLdapSearchTest"),
                 divSearchTestResults: document.querySelector("#divSearchTestResults"),
+                txtLdapClientCertPath: document.querySelector("#txtLdapClientCertPath"),
+                txtLdapClientKeyPath: document.querySelector("#txtLdapClientKeyPath"),
+                txtLdapRootCaPath: document.querySelector("#txtLdapRootCaPath"),
                 chkEnableUserCreation: document.querySelector("#chkEnableUserCreation"),
                 txtLdapUsernameAttribute: document.querySelector("#txtLdapUsernameAttribute"),
                 txtLdapPasswordAttribute: document.querySelector("#txtLdapPasswordAttribute"),
@@ -219,6 +234,9 @@
                     LdapConfigurationPage.txtLdapAdminFilter.value =
                         (config.LdapAdminFilter === '_disabled_') ? "" : config.LdapAdminFilter;
                     LdapConfigurationPage.txtLdapSearchAttributes.value = config.LdapSearchAttributes;
+                    LdapConfigurationPage.txtLdapClientCertPath.value = config.LdapClientCertPath || "";
+                    LdapConfigurationPage.txtLdapClientKeyPath.value = config.LdapClientKeyPath || "";
+                    LdapConfigurationPage.txtLdapRootCaPath.value = config.LdapRootCaPath || "";
                     LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked = config.EnableCaseInsensitiveUsername;
                     LdapConfigurationPage.chkEnableUserCreation.checked = config.CreateUsersFromLdap;
                     LdapConfigurationPage.txtLdapUsernameAttribute.value = config.LdapUsernameAttribute;
@@ -302,6 +320,9 @@
                     config.LdapAdminBaseDn = LdapConfigurationPage.txtLdapAdminBaseDn.value;
                     config.LdapAdminFilter = LdapConfigurationPage.txtLdapAdminFilter.value || '_disabled_';
                     config.LdapSearchAttributes = LdapConfigurationPage.txtLdapSearchAttributes.value;
+                    config.LdapClientCertPath = LdapConfigurationPage.txtLdapClientCertPath.value;
+                    config.LdapClientKeyPath = LdapConfigurationPage.txtLdapClientKeyPath.value;
+                    config.LdapRootCaPath = LdapConfigurationPage.txtLdapRootCaPath.value;
                     config.EnableCaseInsensitiveUsername = LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked;
                     config.CreateUsersFromLdap = LdapConfigurationPage.chkEnableUserCreation.checked;
                     config.LdapUsernameAttribute = LdapConfigurationPage.txtLdapUsernameAttribute.value;
@@ -339,6 +360,9 @@
                     LdapBindPassword: LdapConfigurationPage.txtLdapBindPassword.value,
                     LdapBaseDn: LdapConfigurationPage.txtLdapBaseDn.value,
                     PasswordResetUrl: LdapConfigurationPage.txtPasswordResetUrl.value,
+                    LdapClientCertPath: LdapConfigurationPage.txtLdapClientCertPath.value,
+                    LdapClientKeyPath: LdapConfigurationPage.txtLdapClientKeyPath.value,
+                    LdapRootCaPath: LdapConfigurationPage.txtLdapRootCaPath.value,
                 }
 
                 const handler = response => response.json().then(res => {


### PR DESCRIPTION
- Allow user to specify Root CA to validate LDAP server cert against
- Allow user to specify client TLS cert/key for authentication with LDAP server

Proposed implementation for #134 