### PR TITLE
Rework search flow to minimize LDAP search results

### DIFF
--- a/LDAP-Auth/Api/LdapController.cs
+++ b/LDAP-Auth/Api/LdapController.cs
@@ -158,7 +158,6 @@ namespace Jellyfin.Plugin.LDAP_Auth.Api
         {
             var configuration = LdapPlugin.Instance.Configuration;
             configuration.LdapSearchAttributes = body.LdapSearchAttributes;
-            configuration.EnableCaseInsensitiveUsername = body.EnableCaseInsensitiveUsername;
             LdapPlugin.Instance.UpdateConfiguration(configuration);
 
             var response = new UserSearchResponse();

--- a/LDAP-Auth/Api/Models/UserFilterInfo.cs
+++ b/LDAP-Auth/Api/Models/UserFilterInfo.cs
@@ -11,7 +11,6 @@ namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
         /// <summary>
         /// Gets or sets the ldap user search filter.
         /// </summary>
-        [Required]
         public string LdapSearchFilter { get; set; }
 
         /// <summary>

--- a/LDAP-Auth/Api/Models/UserSearchAttributes.cs
+++ b/LDAP-Auth/Api/Models/UserSearchAttributes.cs
@@ -12,13 +12,7 @@ namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
         /// <summary>
         /// Gets or sets the ldap search attributes.
         /// </summary>
-        [Required]
         public string LdapSearchAttributes { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to use case insensitive username comparison.
-        /// </summary>
-        public bool EnableCaseInsensitiveUsername { get; set; }
 
         /// <summary>
         /// Gets or sets the username to search for as a test.

--- a/LDAP-Auth/Config/PluginConfiguration.cs
+++ b/LDAP-Auth/Config/PluginConfiguration.cs
@@ -29,7 +29,6 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
             LdapClientCertPath = string.Empty;
             LdapClientKeyPath = string.Empty;
             LdapRootCaPath = string.Empty;
-            EnableCaseInsensitiveUsername = false;
             CreateUsersFromLdap = true;
             LdapUsernameAttribute = "uid";
             LdapPasswordAttribute = "userPassword";
@@ -101,11 +100,6 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
         /// Gets or sets the ldap search attributes.
         /// </summary>
         public string LdapSearchAttributes { get; set; }
-
-        /// <summary>
-        /// Gets or sets a value indicating whether to use case insensitive username comparison.
-        /// </summary>
-        public bool EnableCaseInsensitiveUsername { get; set; }
 
         /// <summary>
         /// Gets or sets the ldap client cert path.

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -94,14 +94,14 @@
                         <div class="verticalSection" is="emby-collapse" title="LDAP User Settings">
                             <div class="collapseContent">
                                 <h4 style="margin-top:-0.3em">Users</h4>
-                                <p>There are two methods possible to search for users.</p>
+                                <p>There are two possible methods to search for users:</p>
                                 <ul>
-                                    <li>The {username} variable can be placed directly into the LDAP Search Filter. This variable will be replaced during the search with the entered username. If you use this method, the LDAP Search Attributes value will be ignored, and you must implement the attribute comparison(s) manually in your filter.</li>
-                                    <li>The LDAP Search Filter can be left as a subcomponent of a larger search filter constructed at runtime. For each LDAP Search Attributes entry, the entered username will be used with the attribute as an 'or' condition search filter. If you use this method, the LDAP Search Filter is optional and may be empty. This will be the default if you do not adjust your LDAP Search Filter to include the {username} variable at least once.</li>
+                                    <li>The {username} variable can be placed directly into the LDAP Search Filter. This variable will be replaced during the search with the entered username. If you use this method, the LDAP Search Attributes value is optional and will be ignored, and you must implement the attribute comparison(s) manually in your filter.<br/><i>For example, "(&(objectclass=mailUser)(|(uid={username})(mail={username})))" will explicitly look for the username in either the "uid" or "mail" entries, and the user must be part of "objectclass=mailUser".</i></li>
+                                    <li>The LDAP Search Filter can be used as a subcomponent of a larger search filter constructed at runtime. This is the default if the LDAP Search Filter does not include the {username} variable at least once. For each LDAP Search Attributes entry, the entered username will be used with the attribute as an 'or' condition search filter. If you use this method, the LDAP Search Filter is optional and may be empty.<br/><i>For example, "(objectclass=mailUser)" as the Search Filter and "uid, mail" as the Search Attributes will generate "(&(objectclass=mailUser)(|(uid={username})(mail={username})))" during lookup, functionally identical to the above example.</i></li>
                                 </ul>
-                                <p>At least one method must be chosen and configured below. If upgrading from plugin version 16 or newer, the second option will be used by default.</p>
-                                <p>Note: Usernames are treated case-insensitive regardless of the method, as an LDAP search is not case-sensitive.</p>
-                                <hr>
+                                <p>At least one method must be chosen and configured below. If upgrading from plugin version 16 or older, the second option will be used by default.</p>
+                                <p>Note: Usernames are treated case-insensitive in both cases, as an LDAP search is not case-sensitive.</p>
+                                <br/>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapSearchFilter" placeholder="(memberOf=CN=JellyfinUsers,DC=contoso,DC=com)" label="LDAP Search Filter:" />
                                     <div class="fieldDescription">
@@ -111,11 +111,18 @@
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapSearchAttributes" placeholder="uid, cn, mail, displayName" label="LDAP Search Attributes:" />
                                     <div class="fieldDescription">
-                                        A comma-separated list of attributes to filter the username by.<br/>
+                                        A comma-separated list of attributes to search for the username.<br/>
                                     </div>
                                 </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapUsernameAttribute" required placeholder="uid" label="LDAP Username Attribute:" />
+                                    <div class="fieldDescription">The LDAP attribute to use as the Jellyfin username.<br/><i>For example, 'uid' means we will use the LDAP 'uid' attribute as the Jellyfin username.</i></div>
+                                </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapPasswordAttribute" label="LDAP Password Attribute:" />
+                                    <div class="fieldDescription">The LDAP attribute for the user password; only required if Allow Password Change is enabled.</div>
+                                </div>
                                 <hr>
-
                                 <h4>Administrators</h4>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapAdminBaseDn" label="LDAP Admin Base DN:" />
@@ -161,14 +168,6 @@
                                         <span>Enable User Creation</span>
                                     </label>
                                     <div class="fieldDescription checkboxFieldDescription">Enable user creation in Jellyfin on successful LDAP authentication. User must first exist in LDAP.</div>
-                                </div>
-                                <div class="inputContainer fldExternalAddressFilter">
-                                    <input is="emby-input" type="text" id="txtLdapUsernameAttribute" label="LDAP Name Attribute:" />
-                                    <div class="fieldDescription">The LDAP attribute to create Jellyfin user names from.<br/><i>For example, 'uid' means we will use the LDAP 'uid' attribute as the Jellyfin username.</i></div>
-                                </div>
-                                <div class="inputContainer fldExternalAddressFilter">
-                                    <input is="emby-input" type="text" id="txtLdapPasswordAttribute" label="LDAP Password Attribute:" />
-                                    <div class="fieldDescription">The LDAP attribute to change passwords with (only applies to password change toggle).</div>
                                 </div>
                                 <div class="folderAccessContainer">
                                     <h2>${HeaderLibraryAccess}</h2>

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -93,10 +93,30 @@
                         </div>
                         <div class="verticalSection" is="emby-collapse" title="LDAP User Settings">
                             <div class="collapseContent">
+                                <h4 style="margin-top:-0.3em">Users</h4>
+                                <p>There are two methods possible to search for users.</p>
+                                <ul>
+                                    <li>The {username} variable can be placed directly into the LDAP Search Filter. This variable will be replaced during the search with the entered username. If you use this method, the LDAP Search Attributes value will be ignored, and you must implement the attribute comparison(s) manually in your filter.</li>
+                                    <li>The LDAP Search Filter can be left as a subcomponent of a larger search filter constructed at runtime. For each LDAP Search Attributes entry, the entered username will be used with the attribute as an 'or' condition search filter. If you use this method, the LDAP Search Filter is optional and may be empty. This will be the default if you do not adjust your LDAP Search Filter to include the {username} variable at least once.</li>
+                                </ul>
+                                <p>At least one method must be chosen and configured below. If upgrading from plugin version 16 or newer, the second option will be used by default.</p>
+                                <p>Note: Usernames are treated case-insensitive regardless of the method, as an LDAP search is not case-sensitive.</p>
+                                <hr>
                                 <div class="inputContainer fldExternalAddressFilter">
-                                    <input is="emby-input" type="text" id="txtLdapSearchFilter" required placeholder="(memberOf=CN=JellyfinUsers,DC=contoso,DC=com)" label="LDAP User Filter:" />
-                                    <div class="fieldDescription">The LDAP search filter to find users for Jellyfin, e.g. (objectClass=inetOrgPerson).</div>
+                                    <input is="emby-input" type="text" id="txtLdapSearchFilter" placeholder="(memberOf=CN=JellyfinUsers,DC=contoso,DC=com)" label="LDAP Search Filter:" />
+                                    <div class="fieldDescription">
+                                        LDAP search filter to limit user searches.<br/>
+                                    </div>
                                 </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapSearchAttributes" placeholder="uid, cn, mail, displayName" label="LDAP Search Attributes:" />
+                                    <div class="fieldDescription">
+                                        A comma-separated list of attributes to filter the username by.<br/>
+                                    </div>
+                                </div>
+                                <hr>
+
+                                <h4>Administrators</h4>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapAdminBaseDn" label="LDAP Admin Base DN:" />
                                     <div class="fieldDescription">The LDAP search base dn to find administrative users for Jellyfin, e.g. (cn=admins,dc=contoso,dc=com). Defaults to user dn if empty</div>
@@ -115,22 +135,14 @@
                                         <span>Enable Admin Filter 'memberUid' mode</span>
                                     </label>
                                 </div>
+                                <hr>
+
+                                <h4>Testing</h4>
                                 <button id="btnTestFilters" is="emby-button" type="button" class="raised button block">
                                     <span>Save and Test LDAP Filter Settings</span>
                                 </button>
                                 <div id="divFilterTestResults"></div>
-                                <hr>
-                                <div class="inputContainer fldExternalAddressFilter">
-                                    <input is="emby-input" type="text" id="txtLdapSearchAttributes" required placeholder="uid, cn, mail, displayName" label="LDAP Attributes:" />
-                                    <div class="fieldDescription">A comma-separated list of LDAP attributes to compare with entered usernames.</div>
-                                </div>
-                                <div class="checkboxContainer checkboxContainer-withDescription">
-                                    <label>
-                                        <input type="checkbox" is="emby-checkbox" id="chkEnableCaseInsensitiveUsername" />
-                                        <span>Enable Case Insensitive Username</span>
-                                    </label>
-                                    <div class="fieldDescription checkboxFieldDescription">Enable case insensitive username comparison</div>
-                                </div>
+                                <br/>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapSearchTest" label="Test Login Name:" />
                                     <div class="fieldDescription">A user login to search the LDAP for to test attribute configuration.</div>
@@ -152,7 +164,7 @@
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapUsernameAttribute" label="LDAP Name Attribute:" />
-                                    <div class="fieldDescription">The LDAP attribute to create Jellyfin user names from.</div>
+                                    <div class="fieldDescription">The LDAP attribute to create Jellyfin user names from.<br/><i>For example, 'uid' means we will use the LDAP 'uid' attribute as the Jellyfin username.</i></div>
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapPasswordAttribute" label="LDAP Password Attribute:" />
@@ -206,7 +218,6 @@
                 chkEnableLdapAdminFilterMemberUid: document.querySelector("#chkEnableLdapAdminFilterMemberUid"),
                 divFilterTestResults: document.querySelector("#divFilterTestResults"),
                 txtLdapSearchAttributes: document.querySelector("#txtLdapSearchAttributes"),
-                chkEnableCaseInsensitiveUsername: document.querySelector("#chkEnableCaseInsensitiveUsername"),
                 txtLdapSearchTest: document.querySelector("#txtLdapSearchTest"),
                 divSearchTestResults: document.querySelector("#divSearchTestResults"),
                 txtLdapClientCertPath: document.querySelector("#txtLdapClientCertPath"),
@@ -245,7 +256,6 @@
                     LdapConfigurationPage.txtLdapClientCertPath.value = config.LdapClientCertPath || "";
                     LdapConfigurationPage.txtLdapClientKeyPath.value = config.LdapClientKeyPath || "";
                     LdapConfigurationPage.txtLdapRootCaPath.value = config.LdapRootCaPath || "";
-                    LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked = config.EnableCaseInsensitiveUsername;
                     LdapConfigurationPage.chkEnableUserCreation.checked = config.CreateUsersFromLdap;
                     LdapConfigurationPage.txtLdapUsernameAttribute.value = config.LdapUsernameAttribute;
                     LdapConfigurationPage.txtLdapPasswordAttribute.value = config.LdapPasswordAttribute;
@@ -332,7 +342,6 @@
                     config.LdapClientCertPath = LdapConfigurationPage.txtLdapClientCertPath.value;
                     config.LdapClientKeyPath = LdapConfigurationPage.txtLdapClientKeyPath.value;
                     config.LdapRootCaPath = LdapConfigurationPage.txtLdapRootCaPath.value;
-                    config.EnableCaseInsensitiveUsername = LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked;
                     config.CreateUsersFromLdap = LdapConfigurationPage.chkEnableUserCreation.checked;
                     config.LdapUsernameAttribute = LdapConfigurationPage.txtLdapUsernameAttribute.value;
                     config.LdapPasswordAttribute = LdapConfigurationPage.txtLdapPasswordAttribute.value;
@@ -473,7 +482,6 @@
 
                 const configUpdate = {
                     LdapSearchAttributes: LdapConfigurationPage.txtLdapSearchAttributes.value,
-                    EnableCaseInsensitiveUsername: LdapConfigurationPage.chkEnableCaseInsensitiveUsername.checked,
                     TestSearchUsername: LdapConfigurationPage.txtLdapSearchTest.value,
                 }
 


### PR DESCRIPTION
The previous implementation would search for all users that potentially matched the (mandatory) configured search filter, then loop through the results to find a user matching one of the attributes.

This method worked fine for small instances, but became unwieldy for larger LDAP instances, and could even result in a Size Limit Exceeded error for extremely large databases.

This commit introduces a better method by integrating the user search component into the initial LDAP search by way of the search filter. This will ideally result in only a single LDAP search result for a given user rather than potentially dozens or hundreds, reducing both the runtime complexity of the plugin as well as the load on the LDAP server.

This new method has two potential ways of generating the limited search filter:

First, the existing search filter option may now accept a "{username}" variable within it, which will be interpolated at runtime based on what the user entered. This method allows for very complex queries to be crafted at will, providing better administrator flexibility and options.

Second, if no "{username}" variable is found within the search filter, the filter will be modified at runtime to include all of the search attributes combined with the username to generate a search query which will return any matches between the username and those attributes. For example, given attributes "uid" and "mail", a (base) search filter of "(objectclass=mailUser)", and the entered username "joshua", the following "real" search query would be produced:

  (&(objectclass=mailUser)(|(uid=joshua)(mail=joshua)))

These two methods are, functionally, mutually exclusive: if the search filter contains the "{username}" variable, the search attributes will be ignored and may be blank/empty; on the other side, with valid search attributes, it is no longer necessary to specify a search filter at all, since there will still be a filter on the attributes and username. Thus, the plugin now accepts blank input for both fields in the configuration, though leaving both blank would not work properly.

In both cases with this change, searches are case-insensitive due to the case-insensitivity of LDAP search queries,, so the option for case-insensitive username searches has been removed as obsolete.

The new configuration is also backwards-compatible: if no changes are made to the search filter, the second method above will be used and this should continue to function exactly as expected.

Some debug messages have also been updated to provide a clearer picture of what the plugin is doing at various steps and aid in troubleshooting.

An explanation of the two methods above is included in the plugin configuration page, along with some rearranging of the options, to assist users in configuring the two fields the way they want.

Closes #139 #34
Obsoletes PR #71