### PR TITLE
Implement proper input sanitization to prevent LDAP injection attacks

### DIFF
--- a/LDAP-Auth/Helpers/LdapUtils.cs
+++ b/LDAP-Auth/Helpers/LdapUtils.cs
@@ -1,0 +1,48 @@
+using System.Text;
+
+namespace Jellyfin.Plugin.LDAP_Auth.Helpers
+{
+    /// <summary>
+    /// Provides utility methods for LDAP.
+    /// </summary>
+    public static class LdapUtils
+    {
+        /// <summary>
+        /// Sanitizes a string for use in LDAP search filters.
+        /// <see href="https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.md">OWASP LDAP Injection Prevention Cheat Sheet</see>.
+        /// </summary>
+        /// <param name="input">The input string to be sanitized.</param>
+        /// <returns>The sanitized input string.</returns>
+        public static string SanitizeFilter(string input)
+        {
+            StringBuilder sanitizedinput = new StringBuilder();
+
+            foreach (char c in input)
+            {
+                switch (c)
+                {
+                    case '\\':
+                        sanitizedinput.Append("\\5c");
+                        break;
+                    case '*':
+                        sanitizedinput.Append("\\2a");
+                        break;
+                    case '(':
+                        sanitizedinput.Append("\\28");
+                        break;
+                    case ')':
+                        sanitizedinput.Append("\\29");
+                        break;
+                    case '\u0000': // Null character
+                        sanitizedinput.Append("\\00");
+                        break;
+                    default:
+                        sanitizedinput.Append(c);
+                        break;
+                }
+            }
+
+            return sanitizedinput.ToString();
+        }
+    }
+}

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Jellyfin.Data.Entities;
 using Jellyfin.Data.Enums;
 using Jellyfin.Plugin.LDAP_Auth.Api.Models;
+using Jellyfin.Plugin.LDAP_Auth.Helpers;
 using MediaBrowser.Common;
 using MediaBrowser.Controller.Authentication;
 using MediaBrowser.Controller.Library;
@@ -111,7 +112,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     var ldapUsers = ldapClient.Search(
                         adminBaseDn,
                         LdapConnection.ScopeSub,
-                        AdminFilter.Replace("{username}", username, StringComparison.OrdinalIgnoreCase),
+                        AdminFilter.Replace("{username}", LdapUtils.SanitizeFilter(username), StringComparison.OrdinalIgnoreCase),
                         Array.Empty<string>(),
                         false);
 
@@ -357,11 +358,13 @@ namespace Jellyfin.Plugin.LDAP_Auth
                 LdapPlugin.Instance.Configuration.LdapBindUser,
                 LdapPlugin.Instance.Configuration.LdapBindPassword);
 
+            string sanitizedUsername = LdapUtils.SanitizeFilter(username);
+
             string realSearchFilter;
 
             if (SearchFilter.Contains("{username}", StringComparison.OrdinalIgnoreCase))
             {
-                realSearchFilter = SearchFilter.Replace("{username}", username, StringComparison.OrdinalIgnoreCase);
+                realSearchFilter = SearchFilter.Replace("{username}", sanitizedUsername, StringComparison.OrdinalIgnoreCase);
             }
             else
             {
@@ -376,7 +379,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                         .Append('(')
                         .Append(attr)
                         .Append('=')
-                        .Append(username)
+                        .Append(sanitizedUsername)
                         .Append(')');
                 }
 


### PR DESCRIPTION
This patch sanitizes the `username` input by replacing unsafe characters with their ASCII HEX representation. This is necessary to counteract potential injections of malicious statements into the LDAP search query constructed by the plugin.

Table of unsafe characters and their replacements:
```
\	\\5c
*	\\2a
(	\\28
)	\\29
NUL	\\00
```

References:
https://datatracker.ietf.org/doc/html/rfc4515#section-3
https://cheatsheetseries.owasp.org/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.html#search-filter-escaping
