### PR TITLE
Add profile image synchronization

### DIFF
--- a/LDAP-Auth/Api/Models/LdapUser.cs
+++ b/LDAP-Auth/Api/Models/LdapUser.cs
@@ -14,6 +14,7 @@ namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
         {
             LinkedJellyfinUserId = Guid.Empty;
             LdapUid = string.Empty;
+            ProfileImageHash = string.Empty;
         }
 
         /// <summary>
@@ -25,5 +26,10 @@ namespace Jellyfin.Plugin.LDAP_Auth.Api.Models
         /// Gets or sets the LDAP Uid associated with the user.
         /// </summary>
         public string LdapUid { get; set; }
+
+        /// <summary>
+        /// Gets or sets the profile image hash. This is used to detect if the profile image provided by LDAP changed.
+        /// </summary>
+        public string ProfileImageHash { get; set; }
     }
 }

--- a/LDAP-Auth/Config/PluginConfiguration.cs
+++ b/LDAP-Auth/Config/PluginConfiguration.cs
@@ -37,6 +37,8 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
             LdapUidAttribute = "uid";
             LdapUsernameAttribute = "cn";
             LdapPasswordAttribute = "userPassword";
+            EnableLdapProfileImageSync = false;
+            LdapProfileImageAttribute = "jpegphoto";
             EnableAllFolders = false;
             EnabledFolders = Array.Empty<string>();
 
@@ -154,6 +156,16 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
         public string LdapPasswordAttribute { get; set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether profile images are synchronized from LDAP.
+        /// </summary>
+        public bool EnableLdapProfileImageSync { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap profile image attribute.
+        /// </summary>
+        public string LdapProfileImageAttribute { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether to enable access to all library folders.
         /// </summary>
         public bool EnableAllFolders { get; set; }
@@ -173,7 +185,8 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
         /// </summary>
         /// <param name="userGuid">The user Guid.</param>
         /// <param name="ldapUid">The LDAP UID associated with the user.</param>
-        public void AddUser(Guid userGuid, string ldapUid)
+        /// <param name="profileImageHash">The hash of the profile image provided by LDAP.</param>
+        public void AddUser(Guid userGuid, string ldapUid, string profileImageHash)
         {
             // Ensure we do not have more than one entry for a given user
             // This may happen if a user tries to authenticate after their
@@ -185,7 +198,8 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
             var ldapUser = new LdapUser
             {
                 LinkedJellyfinUserId = userGuid,
-                LdapUid = ldapUid
+                LdapUid = ldapUid,
+                ProfileImageHash = profileImageHash
             };
             ldapUsers.Add(ldapUser);
             LdapUsers = ldapUsers.ToArray();

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -126,6 +126,19 @@
                                     <input is="emby-input" type="text" id="txtLdapPasswordAttribute" label="LDAP Password Attribute:" />
                                     <div class="fieldDescription">The LDAP attribute for the user password; only required if Allow Password Change is enabled.</div>
                                 </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <label>
+                                        <input type="checkbox" is="emby-checkbox" id="chkEnableProfileImageSync" />
+                                        <span>Enable profile image synchronization</span>
+                                    </label>
+                                    <div class="fieldDescription checkboxFieldDescription">
+                                        Note that this is a one way sync. If a user changes their profile image in Jellyfin it won't be updated unless the profile image changes in LDAP or the user deletes it in Jellyfin.</div>
+                                </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <input is="emby-input" type="text" id="txtLdapProfileImageAttribute" label="LDAP Profile Image Attribute:" />
+                                    <div class="fieldDescription">
+                                        The LDAP attribute for synchronizing profile images.
+                                </div>
                                 <hr>
                                 <h4>Administrators</h4>
                                 <div class="inputContainer fldExternalAddressFilter">
@@ -230,6 +243,8 @@
                 txtLdapUidAttribute: document.querySelector("#txtLdapUidAttribute"),
                 txtLdapUsernameAttribute: document.querySelector("#txtLdapUsernameAttribute"),
                 txtLdapPasswordAttribute: document.querySelector("#txtLdapPasswordAttribute"),
+                chkEnableProfileImageSync: document.querySelector("#chkEnableProfileImageSync"),
+                txtLdapProfileImageAttribute: document.querySelector("#txtLdapProfileImageAttribute"),
                 chkEnableAllFolders: document.querySelector('#chkEnableAllFolders'),
                 folderAccessList: document.querySelector('.folderAccess'),
                 txtPasswordResetUrl: document.querySelector("#txtLdapPasswordResetUrl")
@@ -264,6 +279,8 @@
                     LdapConfigurationPage.txtLdapUidAttribute.value = config.LdapUidAttribute;
                     LdapConfigurationPage.txtLdapUsernameAttribute.value = config.LdapUsernameAttribute;
                     LdapConfigurationPage.txtLdapPasswordAttribute.value = config.LdapPasswordAttribute;
+                    LdapConfigurationPage.chkEnableProfileImageSync.checked = config.EnableLdapProfileImageSync;
+                    LdapConfigurationPage.txtLdapProfileImageAttribute.value = config.LdapProfileImageAttribute;
                     config.EnableAllFolders = config.EnableAllFolders || false;
                     LdapConfigurationPage.chkEnableAllFolders.checked = config.EnableAllFolders;
                     /* Default to empty array if Enabled Folders is not set */
@@ -351,6 +368,8 @@
                     config.LdapUidAttribute = LdapConfigurationPage.txtLdapUidAttribute.value;
                     config.LdapUsernameAttribute = LdapConfigurationPage.txtLdapUsernameAttribute.value;
                     config.LdapPasswordAttribute = LdapConfigurationPage.txtLdapPasswordAttribute.value;
+                    config.EnableLdapProfileImageSync = LdapConfigurationPage.chkEnableProfileImageSync.checked;
+                    config.LdapProfileImageAttribute = LdapConfigurationPage.txtLdapProfileImageAttribute.value;
                     /* Map the set of checked input items to an array of library Id's */
                     config.EnableAllFolders = LdapConfigurationPage.chkEnableAllFolders.checked || false;
                     let folders = document.querySelectorAll('#folderList input');

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -132,12 +132,12 @@
                                         <span>Enable profile image synchronization</span>
                                     </label>
                                     <div class="fieldDescription checkboxFieldDescription">
-                                        Note that this is a one way sync. If a user changes their profile image in Jellyfin it won't be updated unless the profile image changes in LDAP or the user deletes it in Jellyfin.</div>
+                                        Note that this is a one way sync. If a user changes their profile image in Jellyfin it won't be updated unless the profile image changes in LDAP or the user deletes it in Jellyfin.
+                                    </div>
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapProfileImageAttribute" label="LDAP Profile Image Attribute:" />
-                                    <div class="fieldDescription">
-                                        The LDAP attribute for synchronizing profile images.
+                                    <div class="fieldDescription">The LDAP attribute for synchronizing profile images.</div>
                                 </div>
                                 <hr>
                                 <h4>Administrators</h4>

--- a/LDAP-Auth/Helpers/ProfileImageUpdater.cs
+++ b/LDAP-Auth/Helpers/ProfileImageUpdater.cs
@@ -1,4 +1,5 @@
 using System.IO;
+using System.Net.Mime;
 using System.Threading.Tasks;
 using Jellyfin.Data.Entities;
 using MediaBrowser.Controller.Configuration;
@@ -26,11 +27,11 @@ namespace Jellyfin.Plugin.LDAP_Auth.Helpers
             IProviderManager providerManager)
         {
             var userDataPath = Path.Combine(serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath, user.Username);
-            user.ProfileImage = new ImageInfo(Path.Combine(userDataPath, $"profile.jpg"));
+            user.ProfileImage = new ImageInfo(Path.Combine(userDataPath, "profile.jpg"));
 
             using var profileImageMemoryStream = new MemoryStream(ldapProfileImage);
             await providerManager
-                .SaveImage(profileImageMemoryStream, "image/jpeg", user.ProfileImage.Path)
+                .SaveImage(profileImageMemoryStream, MediaTypeNames.Image.Jpeg, user.ProfileImage.Path)
                 .ConfigureAwait(false);
         }
     }

--- a/LDAP-Auth/Helpers/ProfileImageUpdater.cs
+++ b/LDAP-Auth/Helpers/ProfileImageUpdater.cs
@@ -1,0 +1,37 @@
+using System.IO;
+using System.Threading.Tasks;
+using Jellyfin.Data.Entities;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Providers;
+
+namespace Jellyfin.Plugin.LDAP_Auth.Helpers
+{
+    /// <summary>
+    /// Provides utility methods to update the profile image of a user.
+    /// </summary>
+    public static class ProfileImageUpdater
+    {
+        /// <summary>
+        /// Sets the profile image of a user to the provided image.
+        /// </summary>
+        /// <param name="user">The user to update.</param>
+        /// <param name="ldapProfileImage">The data representing the profile image to set.</param>
+        /// <param name="serverConfigurationManager">Instance of the <see cref="IServerConfigurationManager"/> interface, used to retrieve the path to save the profile picture.</param>
+        /// <param name="providerManager">Instance of the <see cref="IProviderManager"/> interface, used to save the profile picture.</param>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+        public static async Task SetProfileImage(
+            User user,
+            byte[] ldapProfileImage,
+            IServerConfigurationManager serverConfigurationManager,
+            IProviderManager providerManager)
+        {
+            var userDataPath = Path.Combine(serverConfigurationManager.ApplicationPaths.UserConfigurationDirectoryPath, user.Username);
+            user.ProfileImage = new ImageInfo(Path.Combine(userDataPath, $"profile.jpg"));
+
+            using var profileImageMemoryStream = new MemoryStream(ldapProfileImage);
+            await providerManager
+                .SaveImage(profileImageMemoryStream, "image/jpeg", user.ProfileImage.Path)
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -205,8 +205,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     var ldapProfileImageHash = string.Empty;
                     if (ldapProfileImage is not null && EnableProfileImageSync)
                     {
-                        using var md5Algo = MD5.Create();
-                        ldapProfileImageHash = Convert.ToBase64String(md5Algo.ComputeHash(ldapProfileImage));
+                        ldapProfileImageHash = Convert.ToBase64String(MD5.HashData(ldapProfileImage));
 
                         await ProfileImageUpdater.SetProfileImage(user, ldapProfileImage, serverConfigurationManager, providerManager).ConfigureAwait(false);
                     }

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Security;
+using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
@@ -12,7 +13,9 @@ using Jellyfin.Plugin.LDAP_Auth.Api.Models;
 using Jellyfin.Plugin.LDAP_Auth.Helpers;
 using MediaBrowser.Common;
 using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
 using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Users;
 using Microsoft.Extensions.Logging;
 using Novell.Directory.Ldap;
@@ -43,6 +46,10 @@ namespace Jellyfin.Plugin.LDAP_Auth
         private string UidAttr => LdapPlugin.Instance.Configuration.LdapUidAttribute;
 
         private string UsernameAttr => LdapPlugin.Instance.Configuration.LdapUsernameAttribute;
+
+        private bool EnableProfileImageSync => LdapPlugin.Instance.Configuration.EnableLdapProfileImageSync;
+
+        private string ProfileImageAttr => LdapPlugin.Instance.Configuration.LdapProfileImageAttribute;
 
         private string SearchFilter => LdapPlugin.Instance.Configuration.LdapSearchFilter;
 
@@ -105,7 +112,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     else
                     {
                         // Add the user to our Ldap users
-                        LdapPlugin.Instance.Configuration.AddUser(user.Id, ldapUid);
+                        LdapPlugin.Instance.Configuration.AddUser(user.Id, ldapUid, string.Empty);
                         LdapPlugin.Instance.SaveConfiguration();
                     }
                 }
@@ -192,10 +199,22 @@ namespace Jellyfin.Plugin.LDAP_Auth
                         user.SetPreference(PreferenceKind.EnabledFolders, LdapPlugin.Instance.Configuration.EnabledFolders);
                     }
 
+                    var providerManager = _applicationHost.Resolve<IProviderManager>();
+                    var serverConfigurationManager = _applicationHost.Resolve<IServerConfigurationManager>();
+                    var ldapProfileImage = GetAttribute(ldapUser, ProfileImageAttr)?.ByteValue;
+                    var ldapProfileImageHash = string.Empty;
+                    if (ldapProfileImage is not null && EnableProfileImageSync)
+                    {
+                        using var md5Algo = MD5.Create();
+                        ldapProfileImageHash = Convert.ToBase64String(md5Algo.ComputeHash(ldapProfileImage));
+
+                        await ProfileImageUpdater.SetProfileImage(user, ldapProfileImage, serverConfigurationManager, providerManager).ConfigureAwait(false);
+                    }
+
                     await userManager.UpdateUserAsync(user).ConfigureAwait(false);
 
                     // Add the user to our Ldap users
-                    LdapPlugin.Instance.Configuration.AddUser(user.Id, ldapUid);
+                    LdapPlugin.Instance.Configuration.AddUser(user.Id, ldapUid, ldapProfileImageHash);
                     LdapPlugin.Instance.SaveConfiguration();
                 }
                 else
@@ -455,7 +474,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     LdapPlugin.Instance.Configuration.LdapBaseDn,
                     LdapConnection.ScopeSub,
                     realSearchFilter,
-                    new[] { UsernameAttr, UidAttr },
+                    new[] { UsernameAttr, UidAttr, ProfileImageAttr },
                     false);
             }
             catch (LdapException e)
@@ -512,7 +531,13 @@ namespace Jellyfin.Plugin.LDAP_Auth
             throw new NotImplementedException();
         }
 
-        private LdapAttribute GetAttribute(LdapEntry userEntry, string attr)
+        /// <summary>
+        /// Retrieves the requested attribute from a <see cref="LdapEntry" />.
+        /// </summary>
+        /// <param name="userEntry">The <see cref="LdapEntry" /> to retrieve the attribute from.</param>
+        /// <param name="attr">The attribute to retrieve from the <see cref="LdapEntry" />.</param>
+        /// <returns>The value of the <see cref="LdapEntry" /> or null if it does not exist.</returns>
+        public LdapAttribute GetAttribute(LdapEntry userEntry, string attr)
         {
             var attributeSet = userEntry.GetAttributeSet();
             if (attributeSet.ContainsKey(attr))

--- a/LDAP-Auth/LdapProfileImageSyncTask.cs
+++ b/LDAP-Auth/LdapProfileImageSyncTask.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.LDAP_Auth.Helpers;
+using MediaBrowser.Common;
+using MediaBrowser.Controller.Authentication;
+using MediaBrowser.Controller.Configuration;
+using MediaBrowser.Controller.Library;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Globalization;
+using MediaBrowser.Model.Tasks;
+using Microsoft.Extensions.Logging;
+using Novell.Directory.Ldap;
+
+namespace Jellyfin.Plugin.LDAP_Auth
+{
+    /// <summary>
+    /// Ldap Authentication Provider Plugin.
+    /// </summary>
+    public class LdapProfileImageSyncTask : IScheduledTask
+    {
+        private readonly ILocalizationManager _localization;
+        private readonly IApplicationHost _applicationHost;
+        private readonly ILogger<LdapProfileImageSyncTask> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LdapProfileImageSyncTask"/> class.
+        /// </summary>
+        /// <param name="applicationHost">Instance of the <see cref="IApplicationHost"/> interface.</param>
+        /// <param name="logger">Instance of the <see cref="ILogger{LDAPImageSyncScheduledTask}"/> interface.</param>
+        /// <param name="localization">Instance of the <see cref="ILocalizationManager"/> interface.</param>
+        public LdapProfileImageSyncTask(IApplicationHost applicationHost, ILogger<LdapProfileImageSyncTask> logger, ILocalizationManager localization)
+        {
+            _logger = logger;
+            _localization = localization;
+            _applicationHost = applicationHost;
+        }
+
+        private bool EnableProfileImageSync => LdapPlugin.Instance.Configuration.EnableLdapProfileImageSync;
+
+        private string ProfileImageAttr => LdapPlugin.Instance.Configuration.LdapProfileImageAttribute;
+
+        /// <inheritdoc/>
+        public string Name => "LDAP - Synchronize profile images";
+
+        /// <inheritdoc/>
+        public string Key => "LdapProfileImageSync";
+
+        /// <inheritdoc/>
+        public string Description => "Synchronizes user profile images from LDAP.";
+
+        /// <inheritdoc/>
+        public string Category => _localization.GetLocalizedString("TasksApplicationCategory");
+
+        /// <inheritdoc/>
+        public async Task ExecuteAsync(IProgress<double> progress, CancellationToken cancellationToken)
+        {
+            if (!EnableProfileImageSync)
+            {
+                _logger.LogDebug("Synchronizing profile images is deactivated");
+                return;
+            }
+
+            var ldapAuthProvider = _applicationHost.GetExports<LdapAuthenticationProviderPlugin>(false).First();
+            var userManager = _applicationHost.Resolve<IUserManager>();
+            var providerManager = _applicationHost.Resolve<IProviderManager>();
+            var serverConfigurationManager = _applicationHost.Resolve<IServerConfigurationManager>();
+            var updatePluginConfig = false;
+
+            foreach (var configUser in LdapPlugin.Instance.Configuration.GetAllLdapUsers())
+            {
+                var user = userManager.GetUserById(configUser.LinkedJellyfinUserId);
+                LdapEntry ldapUser;
+                try
+                {
+                    ldapUser = ldapAuthProvider.LocateLdapUser(configUser.LdapUid);
+                }
+                catch (AuthenticationException)
+                {
+                    _logger.LogWarning("User '{configUser}' is not found in LDAP. Cannot synchronize profile image.", configUser.LdapUid);
+                    continue;
+                }
+
+                var ldapProfileImage = ldapAuthProvider.GetAttribute(ldapUser, ProfileImageAttr)?.ByteValue;
+
+                if (ldapProfileImage is not null)
+                {
+                    // Found a profile image in LDAP data. Check image changed since last login and update if it changed
+                    using var md5Algo = MD5.Create();
+                    var ldapProfileImageHash = Convert.ToBase64String(md5Algo.ComputeHash(ldapProfileImage));
+
+                    if (
+                        user.ProfileImage is null ||
+                        !string.Equals(ldapProfileImageHash, configUser.ProfileImageHash, StringComparison.Ordinal))
+                    {
+                        _logger.LogDebug("Updating profile image for user {Username}", configUser.LdapUid);
+
+                        if (user.ProfileImage is not null)
+                        {
+                            await userManager.ClearProfileImageAsync(user).ConfigureAwait(false);
+                        }
+
+                        await ProfileImageUpdater.SetProfileImage(user, ldapProfileImage, serverConfigurationManager, providerManager).ConfigureAwait(false);
+                        configUser.ProfileImageHash = ldapProfileImageHash;
+                        updatePluginConfig = true;
+
+                        await userManager.UpdateUserAsync(user).ConfigureAwait(false);
+                    }
+                }
+                else if (user.ProfileImage is not null)
+                {
+                    // Did not find a profile image in LDAP data but user still has a profile image set. Reset it.
+                    _logger.LogDebug("Removing profile image for user {Username}", configUser.LdapUid);
+
+                    try
+                    {
+                        File.Delete(user.ProfileImage.Path);
+                    }
+                    catch (IOException e)
+                    {
+                        _logger.LogError(e, "Error deleting user profile image during LDAP user profile image update");
+                    }
+
+                    configUser.ProfileImageHash = string.Empty;
+                    updatePluginConfig = true;
+
+                    await userManager.ClearProfileImageAsync(user).ConfigureAwait(false);
+                }
+            }
+
+            if (updatePluginConfig)
+            {
+                LdapPlugin.Instance.SaveConfiguration();
+            }
+        }
+
+        /// <inheritdoc/>
+        public IEnumerable<TaskTriggerInfo> GetDefaultTriggers()
+        {
+            return new[]
+            {
+                new TaskTriggerInfo
+                {
+                    Type = TaskTriggerInfo.TriggerInterval,
+                    IntervalTicks = TimeSpan.FromHours(24).Ticks
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
This PR addresses #85 and implements profile image synchronization from LDAP to Jellyfin.

The profile image is set when a user account is created and automatically synchronized in a configurable interval using a scheduled task. The attribute to retrieve the profile image can be configured and is set to `jpegphoto` by default. Profile image synchronization is disabled by default and can be enabled in the settings.

The profile image is only changed if it has been changed in LDAP. To detect the change a hash of the image is stored in the plugin configuration for the user and compared to the hash of the LDAP attribute when the scheduled task is run. 

This PR has been tested with an LLDAP instance as LDAP-backend, but other LDAP servers should behave the same.
