### PR TITLE
Base64 decode image attribute

### DIFF
--- a/LDAP-Auth/Config/PluginConfiguration.cs
+++ b/LDAP-Auth/Config/PluginConfiguration.cs
@@ -39,6 +39,7 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
             LdapPasswordAttribute = "userPassword";
             EnableLdapProfileImageSync = false;
             LdapProfileImageAttribute = "jpegphoto";
+            LdapProfileImageAttributeFormat = "binary";
             EnableAllFolders = false;
             EnabledFolders = Array.Empty<string>();
 
@@ -164,6 +165,11 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
         /// Gets or sets the ldap profile image attribute.
         /// </summary>
         public string LdapProfileImageAttribute { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap profile image attribute format (binary/base64).
+        /// </summary>
+        public string LdapProfileImageAttributeFormat { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to enable access to all library folders.

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -143,7 +143,7 @@
                                     <select is="emby-select" id="selLdapProfileImageAttributeFormat">
                                         <option value="binary">Binary</option>
                                         <option value="base64">Base64 encoded</option>
-                                        <!--<option value="url">URL</option>-->
+                                        <option value="url">URL</option>
                                     </select>
                                     <div class="fieldDescription">How is the data encoded in the LDAP attribute.</div>
                                 </div>

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -96,31 +96,31 @@
                                 <h4 style="margin-top:-0.3em">Users</h4>
                                 <p>There are two possible methods to search for users:</p>
                                 <ul>
-                                    <li>The {username} variable can be placed directly into the LDAP Search Filter. This variable will be replaced during the search with the entered username. If you use this method, the LDAP Search Attributes value is optional and will be ignored, and you must implement the attribute comparison(s) manually in your filter.<br/><i>For example, "(&(objectclass=mailUser)(|(uid={username})(mail={username})))" will explicitly look for the username in either the "uid" or "mail" entries, and the user must be part of "objectclass=mailUser".</i></li>
-                                    <li>The LDAP Search Filter can be used as a subcomponent of a larger search filter constructed at runtime. This is the default if the LDAP Search Filter does not include the {username} variable at least once. For each LDAP Search Attributes entry, the entered username will be used with the attribute as an 'or' condition search filter. If you use this method, the LDAP Search Filter is optional and may be empty.<br/><i>For example, "(objectclass=mailUser)" as the Search Filter and "uid, mail" as the Search Attributes will generate "(&(objectclass=mailUser)(|(uid={username})(mail={username})))" during lookup, functionally identical to the above example.</i></li>
+                                    <li>The {username} variable can be placed directly into the LDAP Search Filter. This variable will be replaced during the search with the entered username. If you use this method, the LDAP Search Attributes value is optional and will be ignored, and you must implement the attribute comparison(s) manually in your filter.<br /><i>For example, "(&(objectclass=mailUser)(|(uid={username})(mail={username})))" will explicitly look for the username in either the "uid" or "mail" entries, and the user must be part of "objectclass=mailUser".</i></li>
+                                    <li>The LDAP Search Filter can be used as a subcomponent of a larger search filter constructed at runtime. This is the default if the LDAP Search Filter does not include the {username} variable at least once. For each LDAP Search Attributes entry, the entered username will be used with the attribute as an 'or' condition search filter. If you use this method, the LDAP Search Filter is optional and may be empty.<br /><i>For example, "(objectclass=mailUser)" as the Search Filter and "uid, mail" as the Search Attributes will generate "(&(objectclass=mailUser)(|(uid={username})(mail={username})))" during lookup, functionally identical to the above example.</i></li>
                                 </ul>
                                 <p>At least one method must be chosen and configured below. If upgrading from plugin version 16 or older, the second option will be used by default.</p>
                                 <p>Note: Usernames are treated case-insensitive in both cases, as an LDAP search is not case-sensitive.</p>
-                                <br/>
+                                <br />
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapSearchFilter" placeholder="(memberOf=CN=JellyfinUsers,DC=contoso,DC=com)" label="LDAP Search Filter:" />
                                     <div class="fieldDescription">
-                                        LDAP search filter to limit user searches.<br/>
+                                        LDAP search filter to limit user searches.<br />
                                     </div>
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapSearchAttributes" placeholder="uid, cn, mail, displayName" label="LDAP Search Attributes:" />
                                     <div class="fieldDescription">
-                                        A comma-separated list of attributes to search for the username.<br/>
+                                        A comma-separated list of attributes to search for the username.<br />
                                     </div>
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapUidAttribute" required placeholder="uid" label="LDAP Uid Attribute:" />
-                                    <div class="fieldDescription">The LDAP attribute to use to uniquely identify the user.<br/><i>For example, 'uid' means we will use the LDAP 'uid' attribute to uniquely identify the user.</i></div>
+                                    <div class="fieldDescription">The LDAP attribute to use to uniquely identify the user.<br /><i>For example, 'uid' means we will use the LDAP 'uid' attribute to uniquely identify the user.</i></div>
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapUsernameAttribute" required placeholder="cn" label="LDAP Username Attribute:" />
-                                    <div class="fieldDescription">The LDAP attribute to use as the Jellyfin username.<br/><i>For example, 'cn' means we will use the LDAP 'cn' attribute as the Jellyfin username.</i></div>
+                                    <div class="fieldDescription">The LDAP attribute to use as the Jellyfin username.<br /><i>For example, 'cn' means we will use the LDAP 'cn' attribute as the Jellyfin username.</i></div>
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapPasswordAttribute" label="LDAP Password Attribute:" />
@@ -139,6 +139,14 @@
                                     <input is="emby-input" type="text" id="txtLdapProfileImageAttribute" label="LDAP Profile Image Attribute:" />
                                     <div class="fieldDescription">The LDAP attribute for synchronizing profile images.</div>
                                 </div>
+                                <div class="inputContainer fldExternalAddressFilter">
+                                    <select is="emby-select" id="selLdapProfileImageAttributeFormat">
+                                        <option value="binary">Binary</option>
+                                        <option value="base64">Base64 encoded</option>
+                                        <!--<option value="url">URL</option>-->
+                                    </select>
+                                    <div class="fieldDescription">How is the data encoded in the LDAP attribute.</div>
+                                </div>
                                 <hr>
                                 <h4>Administrators</h4>
                                 <div class="inputContainer fldExternalAddressFilter">
@@ -147,7 +155,8 @@
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapAdminFilter" label="LDAP Admin Filter:" />
-                                    <div class="fieldDescription">The LDAP search filter to find administrative users for Jellyfin, e.g. (objectClass=JellyfinAdministrator). Variable {username} is available for more complex filters e.g. (memberUid={username}).
+                                    <div class="fieldDescription">
+                                        The LDAP search filter to find administrative users for Jellyfin, e.g. (objectClass=JellyfinAdministrator). Variable {username} is available for more complex filters e.g. (memberUid={username}).
                                         If left blank, administrative state must be configured manually for each user. If set, administrative access will automatically be applied
                                         (either granting or removing administrative access) when the LDAP user next logs in. If the user is currently logged in, this filter will
                                         not change their active session permissions.
@@ -166,7 +175,7 @@
                                     <span>Save and Test LDAP Filter Settings</span>
                                 </button>
                                 <div id="divFilterTestResults"></div>
-                                <br/>
+                                <br />
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapSearchTest" label="Test Login Name:" />
                                     <div class="fieldDescription">A user login to search the LDAP for to test attribute configuration.</div>
@@ -245,6 +254,7 @@
                 txtLdapPasswordAttribute: document.querySelector("#txtLdapPasswordAttribute"),
                 chkEnableProfileImageSync: document.querySelector("#chkEnableProfileImageSync"),
                 txtLdapProfileImageAttribute: document.querySelector("#txtLdapProfileImageAttribute"),
+                selLdapProfileImageAttributeFormat: document.querySelector("#selLdapProfileImageAttributeFormat"),
                 chkEnableAllFolders: document.querySelector('#chkEnableAllFolders'),
                 folderAccessList: document.querySelector('.folderAccess'),
                 txtPasswordResetUrl: document.querySelector("#txtLdapPasswordResetUrl")
@@ -281,6 +291,7 @@
                     LdapConfigurationPage.txtLdapPasswordAttribute.value = config.LdapPasswordAttribute;
                     LdapConfigurationPage.chkEnableProfileImageSync.checked = config.EnableLdapProfileImageSync;
                     LdapConfigurationPage.txtLdapProfileImageAttribute.value = config.LdapProfileImageAttribute;
+                    LdapConfigurationPage.selLdapProfileImageAttributeFormat.value = config.LdapProfileImageAttributeFormat;
                     config.EnableAllFolders = config.EnableAllFolders || false;
                     LdapConfigurationPage.chkEnableAllFolders.checked = config.EnableAllFolders;
                     /* Default to empty array if Enabled Folders is not set */
@@ -370,6 +381,7 @@
                     config.LdapPasswordAttribute = LdapConfigurationPage.txtLdapPasswordAttribute.value;
                     config.EnableLdapProfileImageSync = LdapConfigurationPage.chkEnableProfileImageSync.checked;
                     config.LdapProfileImageAttribute = LdapConfigurationPage.txtLdapProfileImageAttribute.value;
+                    config.LdapProfileImageAttributeFormat = LdapConfigurationPage.selLdapProfileImageAttributeFormat.value;
                     /* Map the set of checked input items to an array of library Id's */
                     config.EnableAllFolders = LdapConfigurationPage.chkEnableAllFolders.checked || false;
                     let folders = document.querySelectorAll('#folderList input');

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
 using System.Net.Security;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
@@ -212,6 +213,11 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     else if (ProfileImageAttrFormat == "binary")
                     {
                         ldapProfileImage = GetAttribute(ldapUser, ProfileImageAttr)?.ByteValue;
+                    }
+                    else if (ProfileImageAttrFormat == "url")
+                    {
+                        using var client = new HttpClient();
+                        ldapProfileImage = await client.GetByteArrayAsync(GetAttribute(ldapUser, ProfileImageAttr)?.StringValue);
                     }
                     else
                     {

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -201,7 +201,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
 
                     var providerManager = _applicationHost.Resolve<IProviderManager>();
                     var serverConfigurationManager = _applicationHost.Resolve<IServerConfigurationManager>();
-                    var ldapProfileImage = GetAttribute(ldapUser, ProfileImageAttr)?.ByteValue;
+                    var ldapProfileImage = Convert.FromBase64String(GetAttribute(ldapUser, ProfileImageAttr).StringValue);
                     var ldapProfileImageHash = string.Empty;
                     if (ldapProfileImage is not null && EnableProfileImageSync)
                     {

--- a/LDAP-Auth/LdapProfileImageSyncTask.cs
+++ b/LDAP-Auth/LdapProfileImageSyncTask.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
@@ -107,6 +108,11 @@ namespace Jellyfin.Plugin.LDAP_Auth
                 else if (ProfileImageAttrFormat == "binary")
                 {
                     ldapProfileImage = ldapAuthProvider.GetAttribute(ldapUser, ProfileImageAttr)?.ByteValue;
+                }
+                else if (ProfileImageAttrFormat == "url")
+                {
+                    using var client = new HttpClient();
+                    ldapProfileImage = await client.GetByteArrayAsync(ldapAuthProvider.GetAttribute(ldapUser, ProfileImageAttr)?.StringValue);
                 }
                 else
                 {

--- a/LDAP-Auth/LdapProfileImageSyncTask.cs
+++ b/LDAP-Auth/LdapProfileImageSyncTask.cs
@@ -59,6 +59,8 @@ namespace Jellyfin.Plugin.LDAP_Auth
 
         private string ProfileImageAttr => LdapPlugin.Instance.Configuration.LdapProfileImageAttribute;
 
+        private string ProfileImageAttrFormat => LdapPlugin.Instance.Configuration.LdapProfileImageAttributeFormat;
+
         /// <inheritdoc/>
         public string Name => "LDAP - Synchronize profile images";
 
@@ -97,7 +99,19 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     continue;
                 }
 
-                var ldapProfileImage = Convert.FromBase64String(ldapAuthProvider.GetAttribute(ldapUser, ProfileImageAttr).StringValue);
+                byte[] ldapProfileImage = null;
+                if (ProfileImageAttrFormat == "base64")
+                {
+                    ldapProfileImage = Convert.FromBase64String(ldapAuthProvider.GetAttribute(ldapUser, ProfileImageAttr)?.StringValue);
+                }
+                else if (ProfileImageAttrFormat == "binary")
+                {
+                    ldapProfileImage = ldapAuthProvider.GetAttribute(ldapUser, ProfileImageAttr)?.ByteValue;
+                }
+                else
+                {
+                    _logger.LogError("Unknown profile image format: {Format}", ProfileImageAttrFormat);
+                }
 
                 if (ldapProfileImage is not null)
                 {

--- a/LDAP-Auth/LdapProfileImageSyncTask.cs
+++ b/LDAP-Auth/LdapProfileImageSyncTask.cs
@@ -97,7 +97,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     continue;
                 }
 
-                var ldapProfileImage = ldapAuthProvider.GetAttribute(ldapUser, ProfileImageAttr)?.ByteValue;
+                var ldapProfileImage = Convert.FromBase64String(ldapAuthProvider.GetAttribute(ldapUser, ProfileImageAttr).StringValue);
 
                 if (ldapProfileImage is not null)
                 {


### PR DESCRIPTION
Piggy backing on #154.

Users are complaining (#163) because the LDAP attribute expect the binary data of the JPG picture, but for some LDAP servers (Authentik for example) we can't store binary data as it breaks serialization. Instead, this plugin will decode from Base64 to get the binary data. The best way could be to have like a drop-down to select "Binary", "Base64" and even "URL" (but I'm not versed enough in C# for this one), but I've tested this way and it works.