### PR TITLE
Fixed ProfileImage ServiceTask and Format Sync

### DIFF
--- a/LDAP-Auth/Config/PluginConfiguration.cs
+++ b/LDAP-Auth/Config/PluginConfiguration.cs
@@ -38,6 +38,7 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
             LdapUsernameAttribute = "cn";
             LdapPasswordAttribute = "userPassword";
             EnableLdapProfileImageSync = false;
+            RemoveImagesNotInLdap = false;
             LdapProfileImageAttribute = "jpegphoto";
             LdapProfileImageFormat = ProfileImageFormat.Default;
             EnableAllFolders = false;
@@ -160,6 +161,11 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
         /// Gets or sets a value indicating whether profile images are synchronized from LDAP.
         /// </summary>
         public bool EnableLdapProfileImageSync { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating Whether to remove the profile image if it has been removed in LDAP.
+        /// </summary>
+        public bool RemoveImagesNotInLdap { get; set; }
 
         /// <summary>
         /// Gets or sets the ldap profile image attribute.

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -136,6 +136,15 @@
                                     </div>
                                 </div>
                                 <div class="inputContainer fldExternalAddressFilter">
+                                    <label>
+                                        <input type="checkbox" is="emby-checkbox" id="chkRemoveImagesNotInLdap" />
+                                        <span>Remove profile images not in LDAP</span>
+                                    </label>
+                                    <div class="fieldDescription checkboxFieldDescription">
+                                        Note that this will delete any ldap user profile picture that aren't in ldap. Keep off to retain previous profile pictures.
+                                    </div>
+                                </div>
+                                <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapProfileImageAttribute" label="LDAP Profile Image Attribute:" />
                                     <div class="fieldDescription">The LDAP attribute for synchronizing profile images.</div>
                                 </div>
@@ -255,7 +264,9 @@
                 txtLdapUsernameAttribute: document.querySelector("#txtLdapUsernameAttribute"),
                 txtLdapPasswordAttribute: document.querySelector("#txtLdapPasswordAttribute"),
                 chkEnableProfileImageSync: document.querySelector("#chkEnableProfileImageSync"),
+                chkRemoveImagesNotInLdap: document.querySelector("#chkRemoveImagesNotInLdap"),
                 txtLdapProfileImageAttribute: document.querySelector("#txtLdapProfileImageAttribute"),
+                selLdapProfileImageFormat: document.querySelector("#selLdapProfileImageFormat"),
                 chkEnableAllFolders: document.querySelector('#chkEnableAllFolders'),
                 folderAccessList: document.querySelector('.folderAccess'),
                 txtPasswordResetUrl: document.querySelector("#txtLdapPasswordResetUrl")
@@ -291,7 +302,9 @@
                     LdapConfigurationPage.txtLdapUsernameAttribute.value = config.LdapUsernameAttribute;
                     LdapConfigurationPage.txtLdapPasswordAttribute.value = config.LdapPasswordAttribute;
                     LdapConfigurationPage.chkEnableProfileImageSync.checked = config.EnableLdapProfileImageSync;
+                    LdapConfigurationPage.chkRemoveImagesNotInLdap.checked = config.RemoveImagesNotInLdap;
                     LdapConfigurationPage.txtLdapProfileImageAttribute.value = config.LdapProfileImageAttribute;
+                    LdapConfigurationPage.selLdapProfileImageFormat.value = config.LdapProfileImageFormat;
                     config.EnableAllFolders = config.EnableAllFolders || false;
                     LdapConfigurationPage.chkEnableAllFolders.checked = config.EnableAllFolders;
                     /* Default to empty array if Enabled Folders is not set */
@@ -380,7 +393,9 @@
                     config.LdapUsernameAttribute = LdapConfigurationPage.txtLdapUsernameAttribute.value;
                     config.LdapPasswordAttribute = LdapConfigurationPage.txtLdapPasswordAttribute.value;
                     config.EnableLdapProfileImageSync = LdapConfigurationPage.chkEnableProfileImageSync.checked;
+                    config.RemoveImagesNotInLdap = LdapConfigurationPage.chkRemoveImagesNotInLdap.checked;
                     config.LdapProfileImageAttribute = LdapConfigurationPage.txtLdapProfileImageAttribute.value;
+                    config.LdapProfileImageFormat = LdapConfigurationPage.selLdapProfileImageFormat.value;
                     /* Map the set of checked input items to an array of library Id's */
                     config.EnableAllFolders = LdapConfigurationPage.chkEnableAllFolders.checked || false;
                     let folders = document.querySelectorAll('#folderList input');

--- a/LDAP-Auth/Helpers/LdapUtils.cs
+++ b/LDAP-Auth/Helpers/LdapUtils.cs
@@ -1,48 +1,80 @@
+using System;
+using System.Buffers.Text;
 using System.Text;
+using ICU4N.Impl;
+using Jellyfin.Plugin.LDAP_Auth.Config;
+using Microsoft.Extensions.Logging;
+using Novell.Directory.Ldap;
 
-namespace Jellyfin.Plugin.LDAP_Auth.Helpers
+namespace Jellyfin.Plugin.LDAP_Auth.Helpers;
+
+/// <summary>
+/// Provides utility methods for LDAP.
+/// </summary>
+public static class LdapUtils
 {
     /// <summary>
-    /// Provides utility methods for LDAP.
+    /// Sanitizes a string for use in LDAP search filters.
+    /// <see href="https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.md">OWASP LDAP Injection Prevention Cheat Sheet</see>.
     /// </summary>
-    public static class LdapUtils
+    /// <param name="input">The input string to be sanitized.</param>
+    /// <returns>The sanitized input string.</returns>
+    public static string SanitizeFilter(string input)
     {
-        /// <summary>
-        /// Sanitizes a string for use in LDAP search filters.
-        /// <see href="https://github.com/OWASP/CheatSheetSeries/blob/master/cheatsheets/LDAP_Injection_Prevention_Cheat_Sheet.md">OWASP LDAP Injection Prevention Cheat Sheet</see>.
-        /// </summary>
-        /// <param name="input">The input string to be sanitized.</param>
-        /// <returns>The sanitized input string.</returns>
-        public static string SanitizeFilter(string input)
-        {
-            StringBuilder sanitizedinput = new StringBuilder();
+        StringBuilder sanitizedinput = new StringBuilder();
 
-            foreach (char c in input)
+        foreach (char c in input)
+        {
+            switch (c)
             {
-                switch (c)
-                {
-                    case '\\':
-                        sanitizedinput.Append("\\5c");
-                        break;
-                    case '*':
-                        sanitizedinput.Append("\\2a");
-                        break;
-                    case '(':
-                        sanitizedinput.Append("\\28");
-                        break;
-                    case ')':
-                        sanitizedinput.Append("\\29");
-                        break;
-                    case '\u0000': // Null character
-                        sanitizedinput.Append("\\00");
-                        break;
-                    default:
-                        sanitizedinput.Append(c);
-                        break;
-                }
+                case '\\':
+                    sanitizedinput.Append("\\5c");
+                    break;
+                case '*':
+                    sanitizedinput.Append("\\2a");
+                    break;
+                case '(':
+                    sanitizedinput.Append("\\28");
+                    break;
+                case ')':
+                    sanitizedinput.Append("\\29");
+                    break;
+                case '\u0000': // Null character
+                    sanitizedinput.Append("\\00");
+                    break;
+                default:
+                    sanitizedinput.Append(c);
+                    break;
+            }
+        }
+
+        return sanitizedinput.ToString();
+    }
+
+    internal static ProfileImageFormat TryDetermineAttributeFormat(LdapAttribute value, ILogger logger)
+    {
+        logger.LogDebug("Trying to determine ProfileImage Format based on Attribute value");
+        var stringValue = value.StringValue;
+        if (Uri.TryCreate(stringValue, UriKind.RelativeOrAbsolute, out var uri))
+        {
+            // We can handle Url schemes as long as its http or https
+            if (uri.Scheme == Uri.UriSchemeHttps || uri.Scheme == Uri.UriSchemeHttp)
+            {
+                logger.LogDebug("Attribute value was valid URI and scheme was one of (http, https). ImageFormat Url");
+                return ProfileImageFormat.Url;
             }
 
-            return sanitizedinput.ToString();
+            throw new InvalidFormatException($"ProfileImage Format detection failed. Attribute value was a valid URI but had an invalid Scheme, expected one of [http, https]. Got: {uri.Scheme}");
         }
+
+        // If the string is entirely valid Base64 we are gonna assume it is Base64
+        if (Base64.IsValid(stringValue))
+        {
+            logger.LogDebug("Attribute value was valid Base64. ImageFormat Base64");
+            return ProfileImageFormat.Base64;
+        }
+
+        logger.LogDebug("Attribute value wasn't valid Uri or Base64. ImageFormat Binary");
+        return ProfileImageFormat.Binary;
     }
 }


### PR DESCRIPTION
This is a bit of a big one following up from #174.

Two bits that fell through the cracks:
* Profile Images are also periodically updated via a service task
* To save the settings from the UI some JS is required to make it work.

Both of these have been fixed in this PR with the addition of a new `RemoveImagesNotInLdap` to stop the plugin from **always** deleting the profile pictures in jellyfin.

Other than that I took the liberty to do a few small code style improvements to bring the code more inline with modern C#. (can split all the primary constructor stuff in a separate PR if required).