### PR TITLE
Improve binary/uri ProfileImage handling

### DIFF
--- a/LDAP-Auth/Helpers/LdapUtils.cs
+++ b/LDAP-Auth/Helpers/LdapUtils.cs
@@ -55,6 +55,16 @@ public static class LdapUtils
     {
         logger.LogDebug("Trying to determine ProfileImage Format based on Attribute value");
         var stringValue = value.StringValue;
+
+        foreach (char c in stringValue)
+        {
+            if (c == 0x7F || (c < 0x20 && c != '\n' && c != '\r' && c != '\t'))
+            {
+                logger.LogDebug("Attribute value contains non-printable control char 0x{cInt:X}. ImageFormat Binary", Convert.ToInt32(c));
+                return ProfileImageFormat.Binary;
+            }
+        }
+
         if (Uri.TryCreate(stringValue, UriKind.RelativeOrAbsolute, out var uri))
         {
             // URI must be absolute for it to contain the Scheme

--- a/LDAP-Auth/Helpers/LdapUtils.cs
+++ b/LDAP-Auth/Helpers/LdapUtils.cs
@@ -57,6 +57,12 @@ public static class LdapUtils
         var stringValue = value.StringValue;
         if (Uri.TryCreate(stringValue, UriKind.RelativeOrAbsolute, out var uri))
         {
+            // URI must be absolute for it to contain the Scheme
+            if (!uri.IsAbsoluteUri)
+            {
+                throw new InvalidFormatException($"ProfileImage Format detection failed. Expected absolute URI but attribute value appears to be a relative path. Got: {uri}");
+            }
+
             // We can handle Url schemes as long as its http or https
             if (uri.Scheme == Uri.UriSchemeHttps || uri.Scheme == Uri.UriSchemeHttp)
             {

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Allows the administrator to customize most aspects of the LDAP authentication pr
 
 ## Build
 
-1. To build this plugin you will need [.Net 6.x](https://dotnet.microsoft.com/download/dotnet/6.0).
+1. To build this plugin you will need [.Net 9.x SDK](https://dotnet.microsoft.com/download/dotnet/9.0).
 
 2. Build plugin with following command
   ```


### PR DESCRIPTION
### Problem

Some binary images seem to falsely trip the `TryNew`—*maybe* because it contains a string like `567890:hjklmnopqrstuvwxyz` in a couple spots—so it throws an `InvalidOperationException` when it gets to the `uri.Scheme` checks, thus causing both login and the image sync task to fail.

### Solutions

This PR solves the first issue by scanning for any non-printable ASCII control codes (apart from `\r`, `\n` etc.) in the `stringValue` to avoid the false positive entirely.

To solve the second issue for relative paths (or any URI without a scheme), an additional check is added to first ensure the URI is an absolute one. Still an exception, but hopefully much clearer for the user as to what went wrong.