### PR TITLE
fix: use case-insensitive comparison before renaming user

### DIFF
--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -254,7 +254,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                 var userNeedsUpdate = false;
 
                 // User exists; if needed update its username
-                if (!string.Equals(user.Username, ldapUsername, StringComparison.Ordinal))
+                if (!string.Equals(user.Username, ldapUsername, StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogDebug("Updating user {Username} username to: {LdapUsername}.", user.Username, ldapUsername);
                     // userManager will take care of saving the new name to DB


### PR DESCRIPTION
Jellyfin-plugin-ldapauth in Jellyfin 10.11.x now throws an ArgumentException if RenameUser is called with a name that differs only by case. This updates the plugin to use OrdinalIgnoreCase when checking if a rename is necessary, preventing login failures for existing LDAP users with casing differences.

Fixes: #201