### PR TITLE
Fix enable all folders checkbox logic

### DIFF
--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -353,7 +353,9 @@
                         const folders = document.querySelectorAll('#folderList input');
                         let count = 0;
                         Array.prototype.forEach.call(folders, folder => folder.checked && count++);
-                        LdapConfigurationPage.chkEnableAllFolders.checked = count == folders.length;
+                        if (count < folders.length) {
+                          LdapConfigurationPage.chkEnableAllFolders.checked = false;
+                        }
                       });
                     });
                     LdapConfigurationPage.chkEnableAllFolders.addEventListener('change', (event) => {


### PR DESCRIPTION
Update checkbox behaviour for enabling all folders based on selection. No longer check "Enable access to all libraries" box when all libraries are checked.

Allows all current libraries to be made accessible to LDAP users, without automatically allowing access to new libraries.

Fixes #204 