### PR TITLE
Support SASL EXTERNAL Binds

### DIFF
--- a/LDAP-Auth/Config/PluginConfiguration.cs
+++ b/LDAP-Auth/Config/PluginConfiguration.cs
@@ -7,6 +7,22 @@ using Jellyfin.Plugin.LDAP_Auth.Api.Models;
 namespace Jellyfin.Plugin.LDAP_Auth.Config
 {
     /// <summary>
+    /// LDAP Bind Method.
+    /// </summary>
+    public enum BindMethod
+    {
+        /// <summary>
+        /// Simple user/password bind.
+        /// </summary>
+        Simple,
+
+        /// <summary>
+        /// SASL External bind.
+        /// </summary>
+        External
+    }
+
+    /// <summary>
     /// Plugin Configuration.
     /// </summary>
     public class PluginConfiguration : MediaBrowser.Model.Plugins.BasePluginConfiguration
@@ -22,6 +38,7 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
             UseSsl = true;
             UseStartTls = false;
             SkipSslVerify = false;
+            LdapBindMethod = BindMethod.Simple;
             LdapBindUser = "CN=BindUser,DC=contoso,DC=com";
             LdapBindPassword = "password";
             LdapBaseDn = "o=domains,dc=contoso,dc=com";
@@ -76,6 +93,11 @@ namespace Jellyfin.Plugin.LDAP_Auth.Config
         /// Gets or sets a value indicating whether to skip ssl verification.
         /// </summary>
         public bool SkipSslVerify { get; set; }
+
+        /// <summary>
+        /// Gets or sets the ldap bind method.
+        /// </summary>
+        public BindMethod LdapBindMethod { get; set; }
 
         /// <summary>
         /// Gets or sets the ldap bind user dn.

--- a/LDAP-Auth/Config/configPage.html
+++ b/LDAP-Auth/Config/configPage.html
@@ -73,6 +73,13 @@
                                         </br>- $userName
                                     </div>
                                 </div>
+                                <div class="selectContainer">
+                                    <label class="selectLabel" for="selectLdapBindMethod">Bind Method</label>
+                                    <select is="emby-select" id="selectLdapBindMethod">
+                                        <option id="optSimple" value="Simple">Simple</option>
+                                        <option id="optExternal" value="External">External</option>
+                                    </select>
+                                </div>
                                 <div class="inputContainer fldExternalAddressFilter">
                                     <input is="emby-input" type="text" id="txtLdapBindUser" label="LDAP Bind User:" />
                                     <div class="fieldDescription">A bind user for LDAP search queries, required if your LDAP doesn't support anonymous bind.</div>
@@ -244,6 +251,7 @@
                 chkUseStartTls: document.querySelector("#chkUseStartTls"),
                 chkSkipSslVerify: document.querySelector("#chkSkipSslVerify"),
                 chkAllowPassChange: document.querySelector("#chkAllowPassChange"),
+                selectLdapBindMethod: document.querySelector("#selectLdapBindMethod"),
                 txtLdapBindUser: document.querySelector("#txtLdapBindUser"),
                 txtLdapBindPassword: document.querySelector("#txtLdapBindPassword"),
                 txtLdapBaseDn: document.querySelector("#txtLdapBaseDn"),
@@ -285,6 +293,7 @@
                     LdapConfigurationPage.chkUseStartTls.checked = config.UseStartTls;
                     LdapConfigurationPage.chkSkipSslVerify.checked = config.SkipSslVerify;
                     LdapConfigurationPage.chkAllowPassChange.checked = config.AllowPassChange;
+                    LdapConfigurationPage.selectLdapBindMethod.value = config.LdapBindMethod;
                     LdapConfigurationPage.txtLdapBindUser.value = config.LdapBindUser;
                     LdapConfigurationPage.txtLdapBindPassword.value = config.LdapBindPassword;
                     LdapConfigurationPage.txtLdapBaseDn.value = config.LdapBaseDn;
@@ -313,6 +322,8 @@
                     loadMediaFolders(config).then(() => {
                       Dashboard.hideLoadingMsg();
                     });
+
+                    toggleBindUserEnabled(LdapConfigurationPage);
                 });
 
                 const updateFolderListVisibility = () => {
@@ -365,6 +376,12 @@
                 }
             });
 
+            function toggleBindUserEnabled(config) {
+                const disableInputs = config.selectLdapBindMethod.value != "Simple";
+                config.txtLdapBindUser.disabled = disableInputs;
+                config.txtLdapBindPassword.disabled = disableInputs;
+            }
+
             var form = document.querySelector(".esqConfigurationForm");
             form.addEventListener("submit", function(e){
                 e.preventDefault();
@@ -377,6 +394,7 @@
                     config.UseStartTls = LdapConfigurationPage.chkUseStartTls.checked;
                     config.AllowPassChange = LdapConfigurationPage.chkAllowPassChange.checked;
                     config.SkipSslVerify = LdapConfigurationPage.chkSkipSslVerify.checked;
+                    config.LdapBindMethod = LdapConfigurationPage.selectLdapBindMethod.value;
                     config.LdapBindUser = LdapConfigurationPage.txtLdapBindUser.value;
                     config.LdapBindPassword = LdapConfigurationPage.txtLdapBindPassword.value;
                     config.LdapBaseDn = LdapConfigurationPage.txtLdapBaseDn.value;
@@ -425,6 +443,7 @@
                     AllowPassChange: LdapConfigurationPage.chkAllowPassChange.checked,
                     UseStartTls: LdapConfigurationPage.chkUseStartTls.checked,
                     SkipSslVerify: LdapConfigurationPage.chkSkipSslVerify.checked,
+                    LdapBindMethod: LdapConfigurationPage.selectLdapBindMethod.value,
                     LdapBindUser: LdapConfigurationPage.txtLdapBindUser.value,
                     LdapBindPassword: LdapConfigurationPage.txtLdapBindPassword.value,
                     LdapBaseDn: LdapConfigurationPage.txtLdapBaseDn.value,
@@ -560,6 +579,10 @@
                 let url = ApiClient.getUrl('ldap/LdapUserSearch');
                 let data = JSON.stringify(configUpdate);
                 ApiClient.ajax({ type: 'POST', url, data, contentType: 'application/json' }).then(handler).catch(handler);
+            });
+
+            document.querySelector("#selectLdapBindMethod").addEventListener("change", function (e) {
+                toggleBindUserEnabled(LdapConfigurationPage);
             });
         </script>
     </div>

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -24,6 +24,7 @@ using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Users;
 using Microsoft.Extensions.Logging;
 using Novell.Directory.Ldap;
+using Novell.Directory.Ldap.Sasl;
 
 namespace Jellyfin.Plugin.LDAP_Auth
 {
@@ -639,11 +640,6 @@ namespace Jellyfin.Plugin.LDAP_Auth
         private LdapConnection ConnectToLdap(string userDn = null, string userPassword = null)
         {
             bool initialConnection = userDn == null;
-            if (initialConnection)
-            {
-                userDn = LdapPlugin.Instance.Configuration.LdapBindUser;
-                userPassword = LdapPlugin.Instance.Configuration.LdapBindPassword;
-            }
 
             // not using `using` for the ability to return ldapClient, need to dispose this manually on exception
             var ldapClient = new LdapConnection(GetConnectionOptions());
@@ -655,8 +651,14 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     ldapClient.StartTls();
                 }
 
-                _logger.LogDebug("Trying bind as user {UserDn}", userDn);
-                ldapClient.Bind(userDn, userPassword);
+                if (initialConnection)
+                {
+                    InitialBind(ldapClient);
+                }
+                else
+                {
+                    ldapClient.Bind(userDn, userPassword);
+                }
             }
             catch (Exception e)
             {
@@ -670,6 +672,23 @@ namespace Jellyfin.Plugin.LDAP_Auth
             }
 
             return ldapClient;
+        }
+
+        private void InitialBind(LdapConnection ldapClient)
+        {
+            switch (LdapPlugin.Instance.Configuration.LdapBindMethod)
+            {
+                case BindMethod.Simple:
+                    string userDn = LdapPlugin.Instance.Configuration.LdapBindUser;
+                    _logger.LogDebug("Trying bind as user {UserDn}", userDn);
+                    ldapClient.Bind(userDn, LdapPlugin.Instance.Configuration.LdapBindPassword);
+                    break;
+
+                case BindMethod.External:
+                    _logger.LogDebug("Trying external bind");
+                    ldapClient.Bind(new SaslExternalRequest());
+                    break;
+            }
         }
 
         /// <summary>
@@ -700,7 +719,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                 }
 
                 response.Bind = Started;
-                ldapClient.Bind(configuration.LdapBindUser, configuration.LdapBindPassword);
+                InitialBind(ldapClient);
                 response.Bind = ldapClient.Bound ? Success : "Anonymous";
 
                 response.BaseSearch = Started;


### PR DESCRIPTION
Add support for SASL EXTERNAL Authentication. This authenticates the LDAP connection via some method external to the LDAP protocol itself; typically, this is done via the TLS Client Certificate configured in the plugin: the subject line will map to a directory object.

This could also be Unix-socket based peer authentication: the kernel will provide the UID and GID of the connection peer, and may use that to map to a directory object or directly in ACLs.

See https://datatracker.ietf.org/doc/html/rfc4422#appendix-A.