### PR TITLE
Backport "Fix IUserManager.RenameUser signature for Jellyfin 12.x" for Jellyfin 10.11.9

### DIFF
--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -259,7 +259,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     _logger.LogDebug("Updating user {Username} username to: {LdapUsername}.", user.Username, ldapUsername);
                     // userManager will take care of saving the new name to DB
                     // no need to do it ourselves
-                    await userManager.RenameUser(user, ldapUsername);
+                    await userManager.RenameUser(user.Id, user.Username, ldapUsername);
                 }
 
                 // User exists; if the admin has enabled an AdminFilter, check if the user's


### PR DESCRIPTION
Backports commit 055a5d4 from unstable to restore compatibility with Jellyfin 10.11.9.

After upgrading Jellyfin from 10.11.8 to 10.11.9, ldap auth fails with:

```
jellyfin  | [08:28:37] [ERR] Error processing request. URL POST /Users/authenticatebyname.
jellyfin  | System.MissingMethodException: Method not found: 'System.Threading.Tasks.Task MediaBrowser.Controller.Library.IUserManager.RenameUser(Jellyfin.Database.Implementations.Entities.User, System.String)'.
```
Based on the commit message, it looks like this was intended for Jellyfin 12.x, but the api change is now already present in Jellyfin 10.11.9 (https://github.com/jellyfin/jellyfin/commit/2ac0edc052ed5d22cee3d46fb933bb12a2b36283), so the current master branch is no longer compatible.
