### PR TITLE
Fix LDAP admin filter username resolution

### DIFF
--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -166,7 +166,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                     var ldapUsers = ldapClient.Search(
                         adminBaseDn,
                         LdapConnection.ScopeSub,
-                        AdminFilter.Replace("{username}", LdapUtils.SanitizeFilter(username), StringComparison.OrdinalIgnoreCase),
+                        AdminFilter.Replace("{username}", LdapUtils.SanitizeFilter(ldapUsername), StringComparison.OrdinalIgnoreCase),
                         Array.Empty<string>(),
                         false);
 
@@ -190,7 +190,7 @@ namespace Jellyfin.Plugin.LDAP_Auth
                 }
                 catch (LdapException e)
                 {
-                    _logger.LogError(e, "Failed to check for admin with: {Filter}", SearchFilter);
+                    _logger.LogError(e, "Failed to check for admin with: {Filter}", AdminFilter);
                     throw new AuthenticationException("Error completing LDAP login while applying admin filter.");
                 }
             }


### PR DESCRIPTION
Fix #222

- use the resolved LDAP username when evaluating `LdapAdminFilter`
- fix the admin-filter error log to report `AdminFilter` instead of `SearchFilter`

Validated against a live LDAP setup where:

- login was allowed by `uid`, `cn`, and `mail`
- Jellyfin usernames were mapped from `cn`
- admin access was controlled through `LdapAdminFilter`

Verified that:

- login with email succeeds
- the correct LDAP-backed Jellyfin user is resolved
- users matching the LDAP admin filter are promoted correctly