### PR TITLE
Active Directory: fix unicodePwd password change and case-only username rename

### DIFF
--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -254,7 +254,9 @@ namespace Jellyfin.Plugin.LDAP_Auth
                 var userNeedsUpdate = false;
 
                 // User exists; if needed update its username
-                if (!string.Equals(user.Username, ldapUsername, StringComparison.Ordinal))
+                // Jellyfin treats usernames case-insensitively and rejects a rename that only changes case,
+                // so only rename when the names really differ.
+                if (!string.Equals(user.Username, ldapUsername, StringComparison.OrdinalIgnoreCase))
                 {
                     _logger.LogDebug("Updating user {Username} username to: {LdapUsername}.", user.Username, ldapUsername);
                     // userManager will take care of saving the new name to DB

--- a/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
+++ b/LDAP-Auth/LDAPAuthenticationProviderPlugin.cs
@@ -315,7 +315,18 @@ namespace Jellyfin.Plugin.LDAP_Auth
             else if (!string.IsNullOrEmpty(LdapPlugin.Instance.Configuration.LdapPasswordAttribute))
             {
                 var passAttr = LdapPlugin.Instance.Configuration.LdapPasswordAttribute;
-                var ldapAttr = new LdapAttribute(passAttr, newPassword);
+                LdapAttribute ldapAttr;
+                if (string.Equals(passAttr, "unicodePwd", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Active Directory: the value must be the password in double quotes, UTF-16LE encoded,
+                    // and the connection must be encrypted (LDAPS or StartTLS) or AD refuses the write.
+                    ldapAttr = new LdapAttribute(passAttr, Encoding.Unicode.GetBytes("\"" + newPassword + "\""));
+                }
+                else
+                {
+                    ldapAttr = new LdapAttribute(passAttr, newPassword);
+                }
+
                 var ldapMod = new LdapModification(LdapModification.Replace, ldapAttr);
 
                 ldapClient.Modify(ldapUser.Dn, ldapMod);


### PR DESCRIPTION
## Summary

Two small, independent fixes in `LDAPAuthenticationProviderPlugin.cs` for running the plugin against Active Directory. Both are one-file changes with no configuration, schema, or API impact, and both are no-ops for deployments that are not affected by the specific condition they handle.

| Commit | Fixes | Change |
|---|---|---|
| Fix `ChangePassword` against Active Directory (`unicodePwd`) | #164, #200 | Encode the value as `"<password>"` in UTF-16LE when the configured password attribute is `unicodePwd` |
| Skip the user rename when names differ only by case | #201 | Compare Jellyfin username and LDAP username with `OrdinalIgnoreCase` before calling `RenameUser` |

The commits are separable; either can be cherry-picked on its own.

Both fixes have been running in production against Windows Server 2022 domain controllers over LDAPS (port 636) with Jellyfin 10.11.11 (plugin 23.x line) and are built and packaged for the 24.x line against Jellyfin 12.

---

## 1. `ChangePassword` against Active Directory

### Symptom

With **Allow Password Change** enabled and **LDAP Password Attribute** set to `unicodePwd`, a password change from the Jellyfin profile page fails. The Jellyfin log shows:

```
[ERR] Error processing request. URL "POST" "/Users/<id>/Password".
LdapException: Unwilling To Perform (53) Unwilling To Perform
LdapException: Server Message: 0000001F: SvcErr: DSID-031A126C, problem 5003 (WILL_NOT_PERFORM), data 0
```

This is the same failure reported in #164 and #200.

### Root cause

`ChangePassword` first checks the root DSE for the Password Modify extended operation (RFC 3062, OID `1.3.6.1.4.1.4203.1.11.1`). Active Directory does not implement it, so the plugin falls through to the "write the attribute directly" branch:

```csharp
var ldapAttr = new LdapAttribute(passAttr, newPassword);
var ldapMod = new LdapModification(LdapModification.Replace, ldapAttr);
ldapClient.Modify(ldapUser.Dn, ldapMod);
```

`LdapAttribute(string, string)` sends the value as a UTF-8 string. Active Directory has a fixed contract for `unicodePwd` writes ([MS-ADTS §3.1.1.3.1.5](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/6e803168-f140-4d23-b2d3-c3a8ab5917d2), and the long-standing KB *"How to change a Windows Active Directory and LDS user password through LDAP"*):

1. The value must be the new password **enclosed in double quotes**, encoded as **UTF-16LE**, sent as a binary (octet-string) value.
2. The connection must be encrypted (LDAPS or StartTLS); AD refuses the write in the clear.
3. A single `replace` of the attribute is treated as an **administrative reset** and requires the *Reset Password* control access right on the target object.

A plain UTF-8 string violates rule 1, and AD rejects it with `0000001F` (`ERROR_GEN_FAILURE`) irrespective of the password's content. This is why the failure looks the same for every password and is not a policy problem (a policy violation returns `0000052D`, `ERROR_PASSWORD_RESTRICTION`).

### Change

```diff
-                var ldapAttr = new LdapAttribute(passAttr, newPassword);
+                LdapAttribute ldapAttr;
+                if (string.Equals(passAttr, "unicodePwd", StringComparison.OrdinalIgnoreCase))
+                {
+                    // Active Directory: the value must be the password in double quotes, UTF-16LE encoded,
+                    // and the connection must be encrypted (LDAPS or StartTLS) or AD refuses the write.
+                    ldapAttr = new LdapAttribute(passAttr, Encoding.Unicode.GetBytes("\"" + newPassword + "\""));
+                }
+                else
+                {
+                    ldapAttr = new LdapAttribute(passAttr, newPassword);
+                }
+
                 var ldapMod = new LdapModification(LdapModification.Replace, ldapAttr);
```

`Encoding.Unicode` is UTF-16LE in .NET. The `LdapAttribute(string, byte[])` constructor in Novell.Directory.Ldap sends the value as an octet string, which is what AD expects. `System.Text` was already imported.

### What it affects

- **Only the `unicodePwd` attribute.** The branch is keyed on the configured attribute name (case-insensitive). Any other value, including the default `userPassword`, follows the existing code path unchanged. OpenLDAP, FreeIPA, 389-ds and similar deployments are not touched.
- **Only the manual-write fallback.** Servers that advertise the Password Modify extended operation continue to use it; this code is never reached for them.
- **Semantics on AD are an admin reset, not a user change.** The write goes over the plugin's bind-user connection, so AD does not re-verify the old password (Jellyfin has already verified it before calling `ChangePassword`), and minimum-password-age and password-history policies are bypassed, as with any reset. Length and complexity are still enforced by AD and surface as a `0000052D` error. The reset is logged on the DC as security event 4724 with the bind account as the subject.
- **Required AD-side configuration**, unchanged by this PR but worth documenting alongside it: the bind account needs the *Reset Password* extended right and write access to `pwdLastSet` on the users' container, and **Use SSL** or **Use StartTLS** must be enabled. Without the delegation the write fails with `00000005` (`INSUFF_ACCESS_RIGHTS`); without encryption it fails with the same `0000001F` as before.

### Verification

- Jellyfin 10.11.11, plugin built from this change, Windows Server 2022 DCs, LDAPS 636, bind account delegated as above, **LDAP Password Attribute** = `unicodePwd`.
- Password change from the profile page succeeds; the new password binds over LDAPS immediately afterwards; `pwdLastSet` updates; the DC logs event 4724 (reset) and 4738 (account changed) with the bind account as subject.
- Passwords containing `"`, `%`, `^`, backtick and other shell-hostile characters were included in testing and are handled correctly (the surrounding quotes are the only ones AD interprets).
- The unpatched plugin on the same configuration reproduces the `0000001F` error on every attempt.

---

## 2. Skip the user rename when names differ only by case

### Symptom

A user whose Jellyfin username differs from their directory username **only in letter case** (for example Jellyfin `Pops`, AD `sAMAccountName` `pops`) cannot log in. The AD bind succeeds, then the login request returns HTTP 500 and the web client shows *"Connection Failure. We're unable to connect to the selected server right now."* The Jellyfin log:

```
[ERR] Error processing request. URL "POST" "/Users/authenticatebyname".
System.ArgumentException: The new and old names must be different.
   at Jellyfin.Server.Implementations.Users.UserManager.RenameUser(Guid userId, String oldName, String newName)
   at Jellyfin.Plugin.LDAP_Auth.LdapAuthenticationProviderPlugin.Authenticate(String username, String password)
   at Jellyfin.Server.Implementations.Users.UserManager.AuthenticateWithProvider(...)
   at Jellyfin.Server.Implementations.Users.UserManager.AuthenticateLocalUser(...)
   at Jellyfin.Server.Implementations.Users.UserManager.AuthenticateUser(...)
```

This is #201. Case differences between a Jellyfin username and a directory username are common in practice: AD's `sAMAccountName` is case-insensitive and often stored in lower case, while Jellyfin users created before LDAP was introduced (or by hand) frequently carry a capitalised name.

### Root cause

After a successful bind, for an existing Jellyfin user, `Authenticate` does:

```csharp
// User exists; if needed update its username
if (!string.Equals(user.Username, ldapUsername, StringComparison.Ordinal))
{
    await userManager.RenameUser(user.Id, user.Username, ldapUsername);
}
```

Here `user.Username` is the name stored on the Jellyfin user that Jellyfin core has already resolved for this login, and `ldapUsername` is the value of the configured username attribute returned by the directory. The comparison is **ordinal**, so `Pops` and `pops` are considered different and `RenameUser` is called.

Jellyfin core, however, treats usernames as case-insensitive. In `Jellyfin.Server.Implementations/Users/UserManager.cs` (10.11 and later) every name operation goes through `NormalizedUsername`, which holds the upper-cased name:

| Operation | Behaviour |
|---|---|
| `GetUserByName(name)` | `u.NormalizedUsername == name.ToUpperInvariant()` |
| `CreateUserAsync(name)` | refuses if any user's `NormalizedUsername` matches |
| `RenameUser(id, oldName, newName)` | throws `ArgumentException("The new and old names must be different.")` when `oldName.Equals(newName, StringComparison.OrdinalIgnoreCase)`; also refuses if another user's `NormalizedUsername` matches |

So from Jellyfin's point of view a case-only rename is not a rename at all, and it throws. The plugin does not catch the exception; it propagates out of `Authenticate` and out of the authentication controller as a 500. The user is locked out on every attempt, with no way to fix it from the Jellyfin side either, because the dashboard's rename goes through the same `RenameUser` and refuses a case-only change as well.

### Change

```diff
                 // User exists; if needed update its username
-                if (!string.Equals(user.Username, ldapUsername, StringComparison.Ordinal))
+                // Jellyfin treats usernames case-insensitively and rejects a rename that only changes case,
+                // so only rename when the names really differ.
+                if (!string.Equals(user.Username, ldapUsername, StringComparison.OrdinalIgnoreCase))
```

### What it affects

The comparison involves exactly two strings, the authenticating user's stored Jellyfin name and that same account's directory name, and decides exactly one thing: whether to ask Jellyfin core for a rename.

- **Names that differ in more than case** are handled exactly as before: `RenameUser` is called and the Jellyfin user is renamed to the directory spelling.
- **Names that differ only in case** are now left alone. The Jellyfin user keeps its existing spelling; login proceeds. Previously this path was a guaranteed exception, so there is no scenario in which the skipped call could have succeeded.
- **Which Jellyfin user is logged in** is not affected. Jellyfin core resolves the user from the typed name (case-insensitively, via `GetUserByName`) before the provider is invoked, and passes the resolved user in.
- **Password verification** is not affected. The directory performs the bind with the credentials as typed.
- **User creation and duplicate detection** are not affected. Both live in Jellyfin core (`CreateUserAsync`, `RenameUser`) and continue to run unchanged on every create and rename. This change cannot introduce duplicate or colliding usernames because it never creates or renames anything; it only refrains from calling `RenameUser` in the one case where core would reject the call.
- **Other users** are not involved; only the authenticating account and its own directory entry are compared.
- **Older Jellyfin versions** that compared usernames ordinally would, with this change, keep a case-mismatched Jellyfin name instead of renaming it. That is cosmetic and arguably the safer behaviour, and the plugin's supported targets (10.11.9+ for 23.x, 12.0+ for 24.x) all use the normalized comparison.

### Verification

- Jellyfin 10.11.11 with an existing Jellyfin user `Pops` and AD `sAMAccountName` `pops`: unpatched plugin fails with the exception above on every login; patched plugin logs in, the Jellyfin user remains `Pops`, and subsequent password change (fix 1) also succeeds.
- Same result for a second user with a mixed-case directory name (`psyc0p4th` in Jellyfin, `PsYc0p4tH` in AD).
- A user whose names differ in more than case is still renamed as before.

---

## Testing notes for reviewers

Both fixes need an Active Directory to reproduce. A minimal setup:

1. Jellyfin 10.11.9+ or 12.0, this plugin, LDAPS to a DC with the DC's issuing CA in **LDAP Root CA Path** (or `Skip SSL verify` for a lab).
2. Fix 1: enable **Allow Password Change**, set **LDAP Password Attribute** to `unicodePwd`, delegate *Reset Password* and `pwdLastSet` write on the users' OU to the bind account, change a password from the profile page.
3. Fix 2: create a Jellyfin user whose name matches an AD account except for case, assign it the LDAP provider, log in.

No changes to configuration keys, the plugin's XML schema, the manifest, or the public surface of the plugin. No new dependencies. Builds warning-free against both target frameworks.
